### PR TITLE
Fix redirection problem after login

### DIFF
--- a/front-end/src/router/index.js
+++ b/front-end/src/router/index.js
@@ -72,7 +72,7 @@ export const constantRouterMap = [
   {
     path: '',
     component: Layout,
-    redirect: 'prometheus',
+    redirect: 'management/tenants',
     meta: {
       title: 'Dashboard',
       icon: 'dashboard'


### PR DESCRIPTION
### Motivation
The current login will be redirected to prometheus, This is not correct when prometheus is not turned on.

### Modifications
* Redirect to the correct page after logging in.