### PR TITLE
An error should be reported when regular expressions exist.

### DIFF
--- a/front-end/src/views/management/namespaceIsolations/namespaceIsolationPolicy.vue
+++ b/front-end/src/views/management/namespaceIsolations/namespaceIsolationPolicy.vue
@@ -336,7 +336,7 @@ export default {
     },
     handleInputConfirmPrimary() {
       const inputValue = this.inputValuePrimary
-      if (this.primaryDynamicTags.indexOf(inputValue) > 0) {
+      if (this.primaryDynamicTags.indexOf(inputValue) >= 0) {
         this.$notify({
           title: 'error',
           message: 'This regex exist',
@@ -367,11 +367,11 @@ export default {
     },
     handleInputConfirmNamespace() {
       const inputValue = this.inputValueNamespace
-      if (this.namespaceDynamicTags.indexOf(inputValue) > 0) {
+      if (this.namespaceDynamicTags.indexOf(inputValue) >= 0) {
         this.$notify({
           title: 'error',
           message: 'This regex exist',
-          type: 'success',
+          type: 'error',
           duration: 3000
         })
         return
@@ -398,7 +398,7 @@ export default {
     },
     handleInputConfirmSecondary() {
       const inputValue = this.inputValueSecondary
-      if (this.secondaryDynamicTags.indexOf(inputValue) > 0) {
+      if (this.secondaryDynamicTags.indexOf(inputValue) >= 0) {
         this.$notify({
           title: 'error',
           message: 'This regex exist',


### PR DESCRIPTION
### Motivation
A warning pops up should be reported when regular expressions exist.
![image](https://user-images.githubusercontent.com/1907867/62202266-91547b80-b3bb-11e9-941e-820a68e9002b.png)

### Modifications
* The same regular expression is not allowed
