### PR TITLE
Fix the problem of too large a docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:8
+FROM openjdk:8-jre-alpine
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -31,17 +31,17 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-RUN apt update
+RUN apk update
 
-RUN apt install -y nginx python-pip
+RUN apk add nginx \
+  && apk add supervisor \
+  && apk add sqlite \
+  && rm  -rf /tmp/* \
+  && rm /var/cache/apk/*
 
-RUN pip install supervisor
+RUN mkdir -p /run/nginx
 
 WORKDIR /pulsar-manager
-
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-
-RUN apt-get install -y nodejs
 
 COPY build/libs/*.jar pulsar-manager.jar
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo 'Starting Pulsar Manager Front end'
 nginx

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -9,5 +9,5 @@ minfds=1024
 minprocs=200
 
 [program:pulsar-manager-backend]
-command = /usr/local/openjdk-8/bin/java -jar /pulsar-manager/pulsar-manager.jar  --redirect.host=%(ENV_REDIRECT_HOST)s --redirect.port=%(ENV_REDIRECT_PORT)s
+command = /usr/bin/java -jar /pulsar-manager/pulsar-manager.jar  --redirect.host=%(ENV_REDIRECT_HOST)s --redirect.port=%(ENV_REDIRECT_PORT)s
 user = root 


### PR DESCRIPTION
### Motivation
At present, the docker image of pulsar-manager is relatively large, causing users to spend a long time downloading, which is unnecessary.

### Modifications
* Move Docker image to openjdk:8-jre-alpine
* Use command apk replace apt
* Install nginx, supervisor, sqlite
* Delete nodejs