### PR TITLE
Time to update cleanup statistics

### DIFF
--- a/src/main/java/io/streamnative/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/io/streamnative/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -130,7 +130,7 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
         });
 
         log.info("Start clearing stats from broker");
-        clearStats(unixTime, clearStatsInterval);
+        clearStats(unixTime, clearStatsInterval / 1000);
     }
 
     public void collectStatsToDB(long unixTime, String env, String cluster, String serviceUrl) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,7 +57,9 @@ redirect.host=localhost
 redirect.port=9527
 
 # Stats interval
+# millisecond
 insert.stats.interval=30000
+# millisecond
 clear.stats.interval=300000
 init.delay.interval=0
 


### PR DESCRIPTION
### Motivation
Currently, the time unit for collecting statistics is milliseconds, and the configuration file is incorrect

### Modifications
* Unify units so that units for collecting and clearing statistical information become milliseconds.
