### PR TITLE
Make default environment persistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build/
 *.db
 front-end/data/
 *.log
+dbdata

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ apiMockitoVersion=1.7.1
 mockitoJunit4Version=1.7.1
 gsonVersion=2.8.2
 postgresqlVersion=42.2.5
-herddbVersion=0.12.0
+herddbVersion=0.12.2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,13 +35,20 @@ mybatis.type-aliases-package=io.streamnative.pulsar.manager
 #spring.datasource.password=
 
 # HerdDB JDBC Driver
- spring.datasource.driver-class-name=herddb.jdbc.Driver
- HerdDB - local in memory-only (check docs for starting an embedded server or embedded replicated server)
- spring.datasource.url=jdbc:herddb:server:localhost:7000?server.base.dir=.
- spring.datasource.schema=classpath:/META-INF/sql/herddb-schema.sql
- spring.datasource.username=sa
- spring.datasource.password=hdb
- spring.datasource.initialization-mode=always
+spring.datasource.driver-class-name=herddb.jdbc.Driver
+# HerdDB - local in memory-only
+#spring.datasource.url=jdbc:herddb:local
+# HerdDB - start embedded server, data persisted on local disk (directory 'dbdata'), listening on localhost:7000
+spring.datasource.url=jdbc:herddb:server:localhost:7000?server.start=true&server.base.dir=dbdata
+# HerdDB - connect to standalone server at localhost:7000
+#spring.datasource.url=jdbc:herddb:server:localhost:7000
+# HerdDB - connect to cluster, uses ZooKeeper for service discovery
+#spring.datasource.url=jdbc:herddb:zookeeper:localhost:2181/herd
+
+spring.datasource.schema=classpath:/META-INF/sql/herddb-schema.sql
+spring.datasource.username=sa
+spring.datasource.password=hdb
+spring.datasource.initialization-mode=always
 
 # postgresql configuration
 #spring.datasource.driver-class-name=org.postgresql.Driver
@@ -57,7 +64,7 @@ zuul.routes.lookup.url=http://localhost:8080/lookup/
         
 # pagehelper plugin
 #pagehelper.helperDialect=sqlite
-# force 'mysql' for HerdDB
+# force 'mysql' for HerdDB, comment out for postgresql
 pagehelper.helperDialect=mysql
 
 backend.directRequestBroker=true


### PR DESCRIPTION
- By default start embedded HerdDB in standalone embedded mode
- By default persist data locally
- Update HerdDB client/server to 0.12.2
- Add more examples in the default application.properties