### PR TITLE
Remove redundant local variables from services' implementation

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/controller/TopicsController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/TopicsController.java
@@ -74,8 +74,7 @@ public class TopicsController {
             @Size(min = 1, max = 255)
             @PathVariable String namespace) {
         String requestHost = environmentCacheService.getServiceUrl(request);
-        Map<String, Object> result = topicsService.getTopicsList(pageNum, pageSize, tenant, namespace, requestHost);
-        return result;
+        return topicsService.getTopicsList(pageNum, pageSize, tenant, namespace, requestHost);
     }
 
     @ApiOperation(value = "Query topic stats info by tenant and namespace")
@@ -101,10 +100,9 @@ public class TopicsController {
             @PathVariable String namespace) {
         String env = request.getHeader("environment");
         String serviceUrl = environmentCacheService.getServiceUrl(request);
-        Map<String, Object> result = topicsService.getTopicStats(
+        return topicsService.getTopicStats(
             pageNum, pageSize,
             tenant, namespace,
             env, serviceUrl);
-        return result;
     }
 }

--- a/src/main/java/org/apache/pulsar/manager/dao/ConsumersStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/ConsumersStatsRepositoryImpl.java
@@ -40,24 +40,19 @@ public class ConsumersStatsRepositoryImpl implements ConsumersStatsRepository {
     public Page<ConsumerStatsEntity> findByTopicStatsId(Integer pageNum, Integer pageSize,
                                                  long topicStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<ConsumerStatsEntity> consumerStatsEntities = consumerStatsMapper.findByTopicStatsId(
-                topicStatsId, timestamp);
-        return consumerStatsEntities;
+        return consumerStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
     }
 
     public Page<ConsumerStatsEntity> findBySubscriptionStatsId(Integer pageNum, Integer pageSize,
                                                                long subscriptionStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<ConsumerStatsEntity> consumerStatsEntities = consumerStatsMapper.findBySubscriptionStatsId(subscriptionStatsId, timestamp);
-        return consumerStatsEntities;
+        return consumerStatsMapper.findBySubscriptionStatsId(subscriptionStatsId, timestamp);
     }
 
     public Page<ConsumerStatsEntity> findByReplicationStatsId(Integer pageNum, Integer pageSize,
                                                               long replicationStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<ConsumerStatsEntity> consumerStatsEntities = consumerStatsMapper.findByReplicationStatsId(
-                replicationStatsId, timestamp);
-        return consumerStatsEntities;
+        return consumerStatsMapper.findByReplicationStatsId(replicationStatsId, timestamp);
     }
 
     public void remove(long timestamp, long timeInterval) {

--- a/src/main/java/org/apache/pulsar/manager/dao/PublishersStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/PublishersStatsRepositoryImpl.java
@@ -39,8 +39,7 @@ public class PublishersStatsRepositoryImpl implements PublishersStatsRepository 
     public Page<PublisherStatsEntity> findByTopicStatsId(Integer pageNum, Integer pageSize,
                                                   long topicStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<PublisherStatsEntity> publisherStatsEntities = publishersStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
-        return publisherStatsEntities;
+        return publishersStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
     }
 
     public void remove(long timestamp, long timeInterval) {

--- a/src/main/java/org/apache/pulsar/manager/dao/ReplicationsStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/ReplicationsStatsRepositoryImpl.java
@@ -39,9 +39,7 @@ public class ReplicationsStatsRepositoryImpl implements ReplicationsStatsReposit
     public Page<ReplicationStatsEntity> findByTopicStatsId(Integer pageNum, Integer pageSize,
                                                     long topicStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<ReplicationStatsEntity> replicationStatsEntities = replicationsStatsMapper.findByTopicStatsId(
-                topicStatsId, timestamp);
-        return replicationStatsEntities;
+        return replicationsStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
     }
 
     public void remove(long timestamp, long timeInterval) {

--- a/src/main/java/org/apache/pulsar/manager/dao/SubscriptionsStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/SubscriptionsStatsRepositoryImpl.java
@@ -39,8 +39,7 @@ public class SubscriptionsStatsRepositoryImpl implements SubscriptionsStatsRepos
     public Page<SubscriptionStatsEntity> findByTopicStatsId(Integer pageNum, Integer pageSize,
                                                      long topicStatsId, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<SubscriptionStatsEntity> subscriptionStatsEntities = subscriptionsStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
-        return subscriptionStatsEntities;
+        return subscriptionsStatsMapper.findByTopicStatsId(topicStatsId, timestamp);
     }
 
     public void remove(long timestamp, long timeInterval) {

--- a/src/main/java/org/apache/pulsar/manager/dao/TopicsStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/TopicsStatsRepositoryImpl.java
@@ -48,9 +48,7 @@ public class TopicsStatsRepositoryImpl implements TopicsStatsRepository {
                                                       String broker,
                                                       long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<TopicStatsEntity> topicStatsEntities =
-            topicsStatsMapper.findByClusterBroker(environment, cluster, broker, timestamp);
-        return topicStatsEntities;
+        return topicsStatsMapper.findByClusterBroker(environment, cluster, broker, timestamp);
     }
 
     public Page<TopicStatsEntity> findByNamespace(Integer pageNum,
@@ -60,9 +58,7 @@ public class TopicsStatsRepositoryImpl implements TopicsStatsRepository {
                                                   String namespace,
                                                   long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<TopicStatsEntity> topicStatsEntities =
-            topicsStatsMapper.findByNamespace(environment, tenant, namespace, timestamp);
-        return topicStatsEntities;
+        return topicsStatsMapper.findByNamespace(environment, tenant, namespace, timestamp);
     }
 
     public Page<TopicStatsEntity> findByMultiTopic(Integer pageNum,
@@ -73,9 +69,7 @@ public class TopicsStatsRepositoryImpl implements TopicsStatsRepository {
                                                    String persistent,
                                                    List<String> topicList, long timestamp) {
         PageHelper.startPage(pageNum, pageSize);
-        Page<TopicStatsEntity> topicStatsEntities = topicsStatsMapper.findByMultiTopic(
-                environment, tenant, namespace, persistent, topicList, timestamp);
-        return topicStatsEntities;
+        return topicsStatsMapper.findByMultiTopic(environment, tenant, namespace, persistent, topicList, timestamp);
     }
 
     public void remove(long timestamp, long timeInterval) {

--- a/src/main/java/org/apache/pulsar/manager/dao/UsersRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/UsersRepositoryImpl.java
@@ -35,8 +35,7 @@ public class UsersRepositoryImpl implements UsersRepository {
 
     @Override
     public long save(UserInfoEntity userInfoEntity) {
-        long userId = this.usersMapper.save(userInfoEntity);
-        return userId;
+        return this.usersMapper.save(userInfoEntity);
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -288,7 +288,6 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
 
     private String[] parseTopic(String topic) {
         String tntPath = topic.split("://")[1];
-        String[] topicPath = tntPath.split("/");
-        return topicPath;
+        return tntPath.split("/");
     }
 }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/EnvironmentCacheServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/EnvironmentCacheServiceImpl.java
@@ -73,8 +73,7 @@ public class EnvironmentCacheServiceImpl implements EnvironmentCacheService {
             // if there is no cluster is specified, forward the request to environment service url
             Optional<EnvironmentEntity> environmentEntityOptional = environmentsRepository.findByName(environment);
             EnvironmentEntity environmentEntity = environmentEntityOptional.get();
-            String directRequestHost = environmentEntity.getBroker();
-            return directRequestHost;
+            return environmentEntity.getBroker();
         } else {
             return getServiceUrl(environment, cluster, 0);
         }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/JwtServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/JwtServiceImpl.java
@@ -104,8 +104,7 @@ public class JwtServiceImpl implements JwtService {
     private Key decodeBySecretKey() {
         try {
             byte[] encodedKey = AuthTokenUtils.readKeyFromUrl(jwtBrokerSecretKey);
-            Key signingKey = AuthTokenUtils.decodeSecretKey(encodedKey);
-            return signingKey;
+            return AuthTokenUtils.decodeSecretKey(encodedKey);
         } catch (IOException e) {
             log.error("Decode failed by secrete key, error: {}", e.getMessage());
             return null;
@@ -132,16 +131,14 @@ public class JwtServiceImpl implements JwtService {
                     .toMillis(RelativeTimeUtil.parseRelativeTimeInSeconds(expiryTime));
             optExpiryTime = Optional.of(new Date(System.currentTimeMillis() + relativeTimeMillis));
         }
-        String token = AuthTokenUtils.createToken(signingKey, role, optExpiryTime);
-        return token;
+        return AuthTokenUtils.createToken(signingKey, role, optExpiryTime);
     }
 
     private Key decodeByPrivateKey() {
         try {
             byte[] encodedKey = AuthTokenUtils.readKeyFromUrl(jwtBrokerPrivateKey);
             SignatureAlgorithm algorithm = SignatureAlgorithm.RS256;
-            Key signingKey = AuthTokenUtils.decodePrivateKey(encodedKey, algorithm);
-            return signingKey;
+            return AuthTokenUtils.decodePrivateKey(encodedKey, algorithm);
         } catch (IOException e) {
             log.error("Decode failed by private key, error: {}", e.getMessage());
             return null;


### PR DESCRIPTION
## Motivation

The modification improves readability and reduces the number of lines.

## Modifications

- Redundant variables (defined right before the return keyword) were removed in favor of the one-line solution.

