### PR TITLE
Ugrade HerdDB to 0.13.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ apiMockitoVersion=1.7.1
 mockitoJunit4Version=1.7.1
 gsonVersion=2.8.2
 postgresqlVersion=42.2.5
-herddbVersion=0.13.0
+herddbVersion=0.13.1
 brokerVersion=2.4.1
 commonsValidatorVersion=1.6


### PR DESCRIPTION
Ugrade HerdDB to 0.13.1
Release notes: https://github.com/diennea/herddb/releases/tag/v0.13.1

Most notable changes are:
Fix issue with aliases in SQL queries https://github.com/diennea/herddb/pull/514 https://github.com/diennea/herddb/issues/513 @tuteng 
Enhanche JDBC metadata https://github.com/diennea/herddb/pull/516
Hide full stacktrace from CLI https://github.com/diennea/herddb/pull/515

Upgrade should be seamless, no data format changes on disk, new code works with old data created with 0.13 and 0.12