### PR TITLE
Add a configuration file for backend service of pulsar manager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,8 @@ COPY docker/supervisord-private-key.conf /etc/
 
 COPY docker/supervisord-secret-key.conf /etc/
 
+COPY docker/supervisord-configuration-file.conf /etc/
+
 COPY docker/default.conf /etc/nginx/conf.d/
 
 COPY docker/startup.sh /pulsar-manager/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,6 +51,10 @@ elif [[ -n "$JWT_TOKEN" ]]
 then
   echo "Enable JWT auth."
   supervisord -c /etc/supervisord-token.conf -n
+elif [[ -n "$SPRING_CONFIGURATION_FILE" ]]
+then
+  echo "Start Pulsar Manager by specifying a configuration file."
+  supervisord -c /etc/supervisord-configuration-file.conf -n
 else
   echo "Start servie no enable JWT."
   supervisord -c /etc/supervisord.conf -n

--- a/docker/supervisord-configuration-file.conf
+++ b/docker/supervisord-configuration-file.conf
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[supervisorctl]
+serverurl=unix:///pulsar-manager/supervisor.sock
+
+[supervisord]
+logfile_maxbytes=50MB
+logfile_backups=10
+nodaemon=false
+minfds=1024
+minprocs=200
+
+[program:pulsar-manager-backend]
+command = /pulsar-manager/pulsar-manager/bin/pulsar-manager  --spring.config.location=%(ENV_SPRING_CONFIGURATION_FILE)s
+user = root


### PR DESCRIPTION
### Motivation

Currently, there are more and more configurable options for pulsar-manger backend services. We need to start the service by specifying a configuration file, which is very useful in a production environment.

### Modification

* Add a `supervisord-configuration-file.conf` profile and start the service through the profile becomes an option.