### PR TITLE
Support display stats for tenant and namespaces

### DIFF
--- a/front-end/src/views/management/tenants/index.vue
+++ b/front-end/src/views/management/tenants/index.vue
@@ -68,6 +68,31 @@
               </el-tag>
             </template>
           </el-table-column>
+          <el-table-column :label="$t('common.inMsg')" align="center">
+            <template slot-scope="scope">
+              <i class="el-icon-download" style="margin-right: 2px"/><span>{{ scope.row.inMsg }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('common.outMsg')" align="center">
+            <template slot-scope="scope">
+              <i class="el-icon-upload2" style="margin-right: 2px"/><span>{{ scope.row.outMsg }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('common.inBytes')" align="center">
+            <template slot-scope="scope">
+              <i class="el-icon-download" style="margin-right: 2px"/><span>{{ scope.row.inBytes }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('common.outBytes')" align="center">
+            <template slot-scope="scope">
+              <i class="el-icon-upload2" style="margin-right: 2px"/><span>{{ scope.row.outBytes }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column :label="$t('common.storageSize')" align="center">
+            <template slot-scope="scope">
+              <span>{{ scope.row.storageSize }}</span>
+            </template>
+          </el-table-column>
           <el-table-column :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
             <template slot-scope="scope">
               <router-link :to="'/management/tenants/tenantInfo/' + scope.row.tenant">
@@ -128,6 +153,9 @@ import {
 } from '@/api/tenants'
 import { fetchClusters } from '@/api/clusters'
 import { validateEmpty } from '@/utils/validate'
+import { formatBytes } from '@/utils/index'
+import { numberFormatter } from '@/filters/index'
+
 const defaultForm = {
   cluster: ''
 }
@@ -197,12 +225,25 @@ export default {
             if (allowedClusters !== '') {
               allowedClustersArray = allowedClusters.split(',')
             }
-            this.localList.push({
+            const data = {
               'tenant': response.data.data[i]['tenant'],
               'namespace': response.data.data[i]['namespaces'],
               'allowedClusters': allowedClustersArray,
-              'adminRoles': adminRolesArray
-            })
+              'adminRoles': adminRolesArray,
+              'inMsg': numberFormatter(0, 2),
+              'outMsg': numberFormatter(0, 2),
+              'inBytes': formatBytes(0),
+              'outBytes': formatBytes(0),
+              'storageSize': formatBytes(0, 0)
+            }
+            if (response.data.data[i].hasOwnProperty('inMsg')) {
+              data['inMsg'] = numberFormatter(response.data.data[i]['inMsg'], 2)
+              data['outMsg'] = numberFormatter(response.data.data[i]['outMsg'], 2)
+              data['inBytes'] = numberFormatter(response.data.data[i]['inBytes'])
+              data['outBytes'] = numberFormatter(response.data.data[i]['outBytes'])
+              data['storageSize'] = numberFormatter(response.data.data[i]['storageSize'], 2)
+            }
+            this.localList.push(data)
           }
           this.total = response.data.total
           this.listQuery.page = response.data.pageNum

--- a/front-end/src/views/management/tenants/tenant.vue
+++ b/front-end/src/views/management/tenants/tenant.vue
@@ -59,6 +59,31 @@
                   </router-link>
                 </template>
               </el-table-column>
+              <el-table-column :label="$t('common.inMsg')" align="center">
+                <template slot-scope="scope">
+                  <i class="el-icon-download" style="margin-right: 2px"/><span>{{ scope.row.inMsg }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('common.outMsg')" align="center">
+                <template slot-scope="scope">
+                  <i class="el-icon-upload2" style="margin-right: 2px"/><span>{{ scope.row.outMsg }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('common.inBytes')" align="center">
+                <template slot-scope="scope">
+                  <i class="el-icon-download" style="margin-right: 2px"/><span>{{ scope.row.inBytes }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('common.outBytes')" align="center">
+                <template slot-scope="scope">
+                  <i class="el-icon-upload2" style="margin-right: 2px"/><span>{{ scope.row.outBytes }}</span>
+                </template>
+              </el-table-column>
+              <el-table-column :label="$t('common.storageSize')" align="center">
+                <template slot-scope="scope">
+                  <span>{{ scope.row.storageSize }}</span>
+                </template>
+              </el-table-column>
               <el-table-column :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
                 <template slot-scope="scope">
                   <router-link :to="'/management/namespaces/' + scope.row.tenant +'/' + scope.row.namespace + '/namespace'">
@@ -159,6 +184,8 @@ import {
   deleteNamespace
 } from '@/api/namespaces'
 import { validateEmpty } from '@/utils/validate'
+import { formatBytes } from '@/utils/index'
+import { numberFormatter } from '@/filters/index'
 
 const defaultForm = {
   tenant: ''
@@ -326,11 +353,24 @@ export default {
       fetchNamespaces(this.postForm.tenant, this.listQuery).then(response => {
         this.listNamespaces = []
         for (var i = 0; i < response.data.data.length; i++) {
-          this.listNamespaces.push({
+          const data = {
             'tenant': this.postForm.tenant,
             'namespace': response.data.data[i].namespace,
-            'topics': response.data.data[i].topics
-          })
+            'topics': response.data.data[i].topics,
+            'inMsg': numberFormatter(0, 2),
+            'outMsg': numberFormatter(0, 2),
+            'inBytes': formatBytes(0),
+            'outBytes': formatBytes(0),
+            'storageSize': formatBytes(0, 0)
+          }
+          if (response.data.data[i].hasOwnProperty('inMsg')) {
+            data['inMsg'] = numberFormatter(response.data.data[i]['inMsg'], 2)
+            data['outMsg'] = numberFormatter(response.data.data[i]['outMsg'], 2)
+            data['inBytes'] = numberFormatter(response.data.data[i]['inBytes'])
+            data['outBytes'] = numberFormatter(response.data.data[i]['outBytes'])
+            data['storageSize'] = numberFormatter(response.data.data[i]['storageSize'], 2)
+          }
+          this.listNamespaces.push(data)
         }
         this.total = this.listNamespaces.length
         // Just to simulate the time of the request

--- a/src/main/java/org/apache/pulsar/manager/dao/TopicsStatsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/TopicsStatsRepositoryImpl.java
@@ -72,6 +72,25 @@ public class TopicsStatsRepositoryImpl implements TopicsStatsRepository {
         return topicsStatsMapper.findByMultiTopic(environment, tenant, namespace, persistent, topicList, timestamp);
     }
 
+    public Page<TopicStatsEntity> findByMultiTenant(Integer pageNum,
+                                             Integer pageSize,
+                                             String environment,
+                                             List<String> tenantList,
+                                             long timestamp) {
+        PageHelper.startPage(pageNum, pageSize);
+        return topicsStatsMapper.findByMultiTenant(environment, tenantList, timestamp);
+    }
+
+    public Page<TopicStatsEntity> findByMultiNamespace(Integer pageNum,
+                                                Integer pageSize,
+                                                String environment,
+                                                String tenant,
+                                                List<String> namespaceList,
+                                                long timestamp) {
+        PageHelper.startPage(pageNum, pageSize);
+        return topicsStatsMapper.findByMultiNamespace(environment, tenant, namespaceList, timestamp);
+    }
+
     public void remove(long timestamp, long timeInterval) {
         topicsStatsMapper.delete(timestamp - timeInterval);
     }

--- a/src/main/java/org/apache/pulsar/manager/entity/TopicsStatsRepository.java
+++ b/src/main/java/org/apache/pulsar/manager/entity/TopicsStatsRepository.java
@@ -48,5 +48,18 @@ public interface TopicsStatsRepository {
                                             List<String> topicList,
                                             long timestamp);
 
+    Page<TopicStatsEntity> findByMultiTenant(Integer pageNum,
+                                            Integer pageSize,
+                                            String environment,
+                                            List<String> tenantList,
+                                            long timestamp);
+
+    Page<TopicStatsEntity> findByMultiNamespace(Integer pageNum,
+                                             Integer pageSize,
+                                             String environment,
+                                             String tenant,
+                                             List<String> namespaceList,
+                                             long timestamp);
+
     void remove(long timestamp, long timeInterval);
 }

--- a/src/main/java/org/apache/pulsar/manager/mapper/TopicsStatsMapper.java
+++ b/src/main/java/org/apache/pulsar/manager/mapper/TopicsStatsMapper.java
@@ -89,6 +89,46 @@ public interface TopicsStatsMapper {
             @Param("topicList") List<String> topicList,
             @Param("timestamp") long timestamp);
 
+    @Select({"<script>",
+            "SELECT environment, tenant,"
+                    + "sum(producer_count) as producerCount,"
+                    + "sum(subscription_count) as subscriptionCount,"
+                    + "sum(msg_rate_in) as msgRateIn,"
+                    + "sum(msg_throughput_in) as msgThroughputIn,"
+                    + "sum(msg_rate_out) as msgRateOut,"
+                    + "sum(msg_throughput_out) as msgThroughputOut,"
+                    + "avg(average_msg_size) as averageMsgSize,"
+                    + "sum(storage_size) as storageSize, time_stamp  FROM topics_stats",
+            "WHERE environment=#{environment} and time_stamp=#{timestamp} and " +
+                    "tenant IN <foreach collection='tenantList' item='tenant' open='(' separator=',' close=')'> #{tenant} </foreach>" +
+                    "GROUP BY environment, tenant, time_stamp" +
+                    "</script>"})
+    Page<TopicStatsEntity> findByMultiTenant(
+            @Param("environment") String environment,
+            @Param("tenantList") List<String> tenantList,
+            @Param("timestamp") long timestamp);
+
+
+    @Select({"<script>",
+            "SELECT environment, tenant, namespace,"
+                    + "sum(producer_count) as producerCount,"
+                    + "sum(subscription_count) as subscriptionCount,"
+                    + "sum(msg_rate_in) as msgRateIn,"
+                    + "sum(msg_throughput_in) as msgThroughputIn,"
+                    + "sum(msg_rate_out) as msgRateOut,"
+                    + "sum(msg_throughput_out) as msgThroughputOut,"
+                    + "avg(average_msg_size) as averageMsgSize,"
+                    + "sum(storage_size) as storageSize, time_stamp  FROM topics_stats",
+            "WHERE environment=#{environment} and tenant=#{tenant} and time_stamp=#{timestamp} and " +
+                    "namespace IN <foreach collection='namespaceList' item='namespace' open='(' separator=',' close=')'> #{namespace} </foreach>" +
+                    "GROUP BY environment, tenant, namespace, time_stamp" +
+                    "</script>"})
+    Page<TopicStatsEntity> findByMultiNamespace(
+            @Param("environment") String environment,
+            @Param("tenant") String tenant,
+            @Param("namespaceList") List<String> namespaceList,
+            @Param("timestamp") long timestamp);
+
     @Delete("DELETE FROM topics_stats WHERE time_stamp < #{refTime}")
     void delete(@Param("refTime") long refTime);
 }

--- a/src/main/java/org/apache/pulsar/manager/service/BrokerStatsService.java
+++ b/src/main/java/org/apache/pulsar/manager/service/BrokerStatsService.java
@@ -13,6 +13,11 @@
  */
 package org.apache.pulsar.manager.service;
 
+import com.github.pagehelper.Page;
+import org.apache.pulsar.manager.entity.TopicStatsEntity;
+
+import java.util.List;
+
 public interface BrokerStatsService {
 
     String forwardBrokerStatsMetrics(String broker, String requestHost);
@@ -22,4 +27,18 @@ public interface BrokerStatsService {
     void collectStatsToDB(long unixTime, String environment, String cluster, String serviceUrl);
 
     void clearStats(long nowTime, long timeInterval);
+
+    Page<TopicStatsEntity> findByMultiTenant(Integer pageNum,
+                                             Integer pageSize,
+                                             String environment,
+                                             List<String> tenantList,
+                                             long timestamp);
+
+    Page<TopicStatsEntity> findByMultiNamespace(Integer pageNum,
+                                                Integer pageSize,
+                                                String environment,
+                                                String tenant,
+                                                List<String> namespaceList,
+                                                long timestamp);
+
 }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -13,6 +13,7 @@
  */
 package org.apache.pulsar.manager.service.impl;
 
+import com.github.pagehelper.Page;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -291,5 +292,23 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
     private String[] parseTopic(String topic) {
         String tntPath = topic.split("://")[1];
         return tntPath.split("/");
+    }
+
+    public Page<TopicStatsEntity> findByMultiTenant(Integer pageNum,
+                                                    Integer pageSize,
+                                                    String environment,
+                                                    List<String> tenantList,
+                                                    long timestamp) {
+        return topicsStatsRepository.findByMultiTenant(pageNum, pageSize, environment, tenantList, timestamp);
+    }
+
+    public Page<TopicStatsEntity> findByMultiNamespace(Integer pageNum,
+                                                       Integer pageSize,
+                                                       String environment,
+                                                       String tenant,
+                                                       List<String> namespaceList,
+                                                       long timestamp) {
+        return topicsStatsRepository.findByMultiNamespace(
+                pageNum, pageSize, environment, tenant, namespaceList, timestamp);
     }
 }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
@@ -19,6 +19,7 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import org.apache.pulsar.manager.entity.TopicStatsEntity;
 import org.apache.pulsar.manager.entity.TopicsStatsRepository;
+import org.apache.pulsar.manager.service.BrokerStatsService;
 import org.apache.pulsar.manager.service.NamespacesService;
 import org.apache.pulsar.manager.service.TopicsService;
 import org.apache.pulsar.manager.utils.HttpUtil;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.*;
 
 @Service
@@ -40,13 +42,19 @@ public class NamespacesServiceImpl implements NamespacesService {
 
     private final TopicsStatsRepository topicsStatsRepository;
     private final TopicsService topicsService;
+    private final HttpServletRequest request;
+    private final BrokerStatsService brokerStatsService;
 
     @Autowired
     public NamespacesServiceImpl(
             TopicsStatsRepository topicsStatsRepository,
-            TopicsService topicsService) {
+            TopicsService topicsService,
+            HttpServletRequest request,
+            BrokerStatsService brokerStatsService) {
         this.topicsStatsRepository = topicsStatsRepository;
         this.topicsService = topicsService;
+        this.request = request;
+        this.brokerStatsService = brokerStatsService;
     }
 
     public Map<String, Object> getNamespaceList(Integer pageNum, Integer pageSize, String tenant, String requestHost) {
@@ -62,6 +70,25 @@ public class NamespacesServiceImpl implements NamespacesService {
             String result = HttpUtil.doGet(requestHost + "/admin/v2/namespaces/" + tenant, header);
             if (result != null) {
                 List<String> namespacesList = gson.fromJson(result, new TypeToken<List<String>>(){}.getType());
+                Optional<TopicStatsEntity> topicStatsEntityOptional = topicsStatsRepository.findMaxTime();
+                Map<String, TopicStatsEntity> topicStatsEntityMap = Maps.newHashMap();
+                if (topicStatsEntityOptional.isPresent()) {
+                    TopicStatsEntity topicStatsEntity = topicStatsEntityOptional.get();
+                    String environment = request.getHeader("environment");
+                    ArrayList<String> namespaceList = new ArrayList<>();
+                    namespaceList.add(topicStatsEntity.getNamespace());
+                    Page<TopicStatsEntity> namespaceCountPage = brokerStatsService.findByMultiNamespace(
+                            1, 1, environment, topicStatsEntity.getTenant(),
+                            namespaceList, topicStatsEntity.getTimestamp());
+                    namespaceCountPage.count(true);
+                    Page<TopicStatsEntity> namespaceAllCountPage = brokerStatsService.findByMultiNamespace(
+                            1, (int)namespaceCountPage.getTotal(), environment, topicStatsEntity.getTenant(),
+                            namespaceList, topicStatsEntity.getTimestamp());
+                    for (TopicStatsEntity statsEntity : namespaceAllCountPage) {
+                        topicStatsEntityMap.put(statsEntity.getNamespace(), statsEntity);
+                    }
+
+                }
                 for (String tenantNamespace : namespacesList) {
                     String namespace = tenantNamespace.split("/")[1];
                     Map<String, Object> topicsEntity = Maps.newHashMap();
@@ -69,6 +96,14 @@ public class NamespacesServiceImpl implements NamespacesService {
                             0, 0, tenant, namespace, requestHost);
                     topicsEntity.put("topics", topics.get("total"));
                     topicsEntity.put("namespace", namespace);
+                    if (topicStatsEntityMap.get(namespace) != null) {
+                        TopicStatsEntity topicStatsEntity = topicStatsEntityMap.get(namespace);
+                        topicsEntity.put("inMsg", topicStatsEntity.getMsgRateIn());
+                        topicsEntity.put("outMsg", topicStatsEntity.getMsgRateOut());
+                        topicsEntity.put("inBytes", topicStatsEntity.getMsgThroughputIn());
+                        topicsEntity.put("outBytes", topicStatsEntity.getMsgThroughputOut());
+                        topicsEntity.put("storageSize", topicStatsEntity.getStorageSize());
+                    }
                     namespacesArray.add(topicsEntity);
                 }
                 namespacesMap.put("isPage", false);

--- a/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
@@ -13,23 +13,30 @@
  */
 package org.apache.pulsar.manager.service.impl;
 
+import com.github.pagehelper.Page;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import org.apache.pulsar.manager.entity.TopicStatsEntity;
+import org.apache.pulsar.manager.entity.TopicsStatsRepository;
+import org.apache.pulsar.manager.service.BrokerStatsService;
 import org.apache.pulsar.manager.service.TenantsService;
 import org.apache.pulsar.manager.utils.HttpUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class TenantsServiceImpl implements TenantsService {
@@ -42,6 +49,15 @@ public class TenantsServiceImpl implements TenantsService {
 
     @Value("${backend.jwt.token}")
     private String pulsarJwtToken;
+
+    @Autowired
+    private BrokerStatsService brokerStatsService;
+
+    @Autowired
+    private TopicsStatsRepository topicsStatsRepository;
+
+    @Autowired
+    private HttpServletRequest request;
 
     public Map<String, Object> getTenantsList(Integer pageNum, Integer pageSize, String requestHost) {
         Map<String, Object> tenantsMap = Maps.newHashMap();
@@ -56,6 +72,20 @@ public class TenantsServiceImpl implements TenantsService {
             String result = HttpUtil.doGet( requestHost + "/admin/v2/tenants", header);
             if (result != null) {
                 List<String> tenantsList = gson.fromJson(result, new TypeToken<List<String>>(){}.getType());
+                Optional<TopicStatsEntity> topicStatsEntityOptional = topicsStatsRepository.findMaxTime();
+                Map<String, TopicStatsEntity> topicStatsEntityMap = Maps.newHashMap();
+                if (topicStatsEntityOptional.isPresent()) {
+                    TopicStatsEntity topicStatsEntity = topicStatsEntityOptional.get();
+                    String environment = request.getHeader("environment");
+                    Page<TopicStatsEntity> tenantCountPage = brokerStatsService.findByMultiTenant(
+                            1, 1, environment, tenantsList, topicStatsEntity.getTimestamp());
+                    tenantCountPage.count(true);
+                    Page<TopicStatsEntity> tenantAllCountPage = brokerStatsService.findByMultiTenant(1,
+                            (int)tenantCountPage.getTotal(), environment, tenantsList, topicStatsEntity.getTimestamp());
+                    for (TopicStatsEntity statsEntity : tenantAllCountPage) {
+                        topicStatsEntityMap.put(topicStatsEntity.getTenant(), statsEntity);
+                    }
+                }
                 for (String tenant : tenantsList) {
                     Map<String, Object> tenantEntity = Maps.newHashMap();
                     String info = HttpUtil.doGet( requestHost + "/admin/v2/tenants/" + tenant, header);
@@ -69,6 +99,14 @@ public class TenantsServiceImpl implements TenantsService {
                         tenantEntity.put("namespaces", namespacesList.size());
                     } else {
                         tenantEntity.put("namespaces", 0);
+                    }
+                    if (topicStatsEntityMap.get(tenant) != null ) {
+                        TopicStatsEntity topicStatsEntity = topicStatsEntityMap.get(tenant);
+                        tenantEntity.put("inMsg", topicStatsEntity.getMsgRateIn());
+                        tenantEntity.put("outMsg", topicStatsEntity.getMsgRateOut());
+                        tenantEntity.put("inBytes", topicStatsEntity.getMsgThroughputIn());
+                        tenantEntity.put("outBytes", topicStatsEntity.getMsgThroughputOut());
+                        tenantEntity.put("storageSize", topicStatsEntity.getStorageSize());
                     }
                     tenantsArray.add(tenantEntity);
                 }


### PR DESCRIPTION
Fix 
https://github.com/apache/pulsar-manager/issues/161
https://github.com/apache/pulsar-manager/issues/198

### Motivation

At present, some users hope to be able to see statistical information on the tenant and namespace pages, so add this feature.

### Modifications
* Add stats information for tenants
* Add stats information for namespaces
* Add unit test for new feature

Tenant page:
![image](https://user-images.githubusercontent.com/1907867/71256557-0a08a400-236c-11ea-8c10-a17e68172dd8.png)

Namespace page:
![image](https://user-images.githubusercontent.com/1907867/71256581-1db40a80-236c-11ea-926e-b2b70ab6cc53.png)


### Verifying this change
Unit test pass