### PR TITLE
Fixed display stats for tenant and namespace

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
@@ -76,13 +76,18 @@ public class NamespacesServiceImpl implements NamespacesService {
                     TopicStatsEntity topicStatsEntity = topicStatsEntityOptional.get();
                     String environment = request.getHeader("environment");
                     ArrayList<String> namespaceList = new ArrayList<>();
-                    namespaceList.add(topicStatsEntity.getNamespace());
+                    for (String namespace : namespacesList) {
+                        String[] path = namespace.split("/");
+                        if (path.length > 1) {
+                            namespaceList.add(path[1]);
+                        }
+                    }
                     Page<TopicStatsEntity> namespaceCountPage = brokerStatsService.findByMultiNamespace(
-                            1, 1, environment, topicStatsEntity.getTenant(),
+                            1, 1, environment, tenant,
                             namespaceList, topicStatsEntity.getTimestamp());
                     namespaceCountPage.count(true);
                     Page<TopicStatsEntity> namespaceAllCountPage = brokerStatsService.findByMultiNamespace(
-                            1, (int)namespaceCountPage.getTotal(), environment, topicStatsEntity.getTenant(),
+                            1, (int)namespaceCountPage.getTotal(), environment, tenant,
                             namespaceList, topicStatsEntity.getTimestamp());
                     for (TopicStatsEntity statsEntity : namespaceAllCountPage) {
                         topicStatsEntityMap.put(statsEntity.getNamespace(), statsEntity);

--- a/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
@@ -83,7 +83,7 @@ public class TenantsServiceImpl implements TenantsService {
                     Page<TopicStatsEntity> tenantAllCountPage = brokerStatsService.findByMultiTenant(1,
                             (int)tenantCountPage.getTotal(), environment, tenantsList, topicStatsEntity.getTimestamp());
                     for (TopicStatsEntity statsEntity : tenantAllCountPage) {
-                        topicStatsEntityMap.put(topicStatsEntity.getTenant(), statsEntity);
+                        topicStatsEntityMap.put(statsEntity.getTenant(), statsEntity);
                     }
                 }
                 for (String tenant : tenantsList) {


### PR DESCRIPTION

### Motivation

At present, because TopicStatsEntity did not get the correct tenant, the stats information display for tenants and namespaces lacks some information. This pr fixes this problem.

### Modifications

* Use the correct tenant and namespace.



