### PR TITLE
Updated supervisord-secret-key.conf

### DIFF
--- a/docker/supervisord-secret-key.conf
+++ b/docker/supervisord-secret-key.conf
@@ -28,5 +28,5 @@ minfds=1024
 minprocs=200
 
 [program:pulsar-manager-backend]
-command = /pulsar-manager/pulsar-manager/bin/pulsar-manager  --redirect.host=%(ENV_REDIRECT_HOST)s --redirect.port=%(ENV_REDIRECT_PORT)s --spring.datasource.driver-class-name=%(ENV_DRIVER_CLASS_NAME)s --spring.datasource.url=%(ENV_URL)s --spring.datasource.username=%(ENV_USERNAME)s --spring.datasource.password=%(ENV_PASSWORD)s --spring.datasource.initialization-mode=never --logging.level.org.apache=%(ENV_LOG_LEVEL)s --backend.jwt.token=%(ENV_JWT_TOKEN)s --jwt.broker.secret.key=%(ENV_SECRET_KEY)s
+command = /pulsar-manager/pulsar-manager/bin/pulsar-manager  --redirect.host=%(ENV_REDIRECT_HOST)s --redirect.port=%(ENV_REDIRECT_PORT)s --spring.datasource.driver-class-name=%(ENV_DRIVER_CLASS_NAME)s --spring.datasource.url=%(ENV_URL)s --spring.datasource.username=%(ENV_USERNAME)s --spring.datasource.password=%(ENV_PASSWORD)s --spring.datasource.initialization-mode=never --logging.level.org.apache=%(ENV_LOG_LEVEL)s --jwt.broker.token.mode=SECRET --backend.jwt.token=%(ENV_JWT_TOKEN)s --jwt.broker.secret.key=%(ENV_SECRET_KEY)s
 user = root


### PR DESCRIPTION
Fix https://github.com/apache/pulsar-manager/issues/260
### Motivation
Token generation requires secret key to be passed to the pulsar-manager.  However simple passing the key as an env variable to the docker container does not work.  --jwt.broker.token.mode=SECRET needs to be set as well.

### Modifications

Added --jwt.broker.token.mode=SECRET to supervisord-secret-key.conf as part  of program:pulsar-manager-backend command line.  


