### PR TITLE
Add entrypoint fix for docker

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,6 +24,7 @@ addgroup pulsar
 adduser --disabled-password --ingroup pulsar pulsar
 mkdir -p /run/postgresql
 chown -R pulsar:pulsar /run/postgresql/
+mkdir /data
 chown -R pulsar:pulsar /data
 chown pulsar:pulsar /pulsar-manager/init_db.sql
 chmod 750 /data
@@ -56,6 +57,6 @@ then
   echo "Start Pulsar Manager by specifying a configuration file."
   supervisord -c /etc/supervisord-configuration-file.conf -n
 else
-  echo "Start servie no enable JWT."
+  echo "Start service without enabling JWT."
   supervisord -c /etc/supervisord.conf -n
 fi


### PR DESCRIPTION
I was working on spinning up a docker-compose.yml file to help with local development with pulsar and found an issue with the entrypoint file.

### Motivation

docker-compose.yml
```
version: "3.7"
services:
  pulsar:
    image: apachepulsar/pulsar:2.5.0
    command: bin/pulsar standalone -a localhost
    ports:
      - "8080:8080"
      - "6650:6650"
    restart: unless-stopped
    volumes:
      - "../data/:/pulsar/data"
      - "./conf/client.conf:/pulsar/conf/client.conf"
      - "./conf/standalone.conf:/pulsar/conf/standalone.conf"
  dashboard:
    image: apachepulsar/pulsar-manager:v0.1.0
    ports:
      - "8888:9527"
    depends_on:
      - pulsar
    environment:
      REDIRECT_HOST: "pulsar"
      REDIRECT_PORT: "8080"
      DRIVER_CLASS_NAME: "org.postgresql.Driver"
      URL: "jdbc:postgresql://127.0.0.1:5432/pulsar_manager"
      USERNAME: "pulsar"
      PASSWORD: "pulsar"
      LOG_LEVEL: "DEBUG"
```

Logs from attempting to spin up the docker container

```
Attaching to dev_dashboard_1
dashboard_1  | Starting PostGreSQL Server
dashboard_1  | chown: /data: No such file or directory
dashboard_1  | chmod: /data: No such file or directory
dashboard_1  | The files belonging to this database system will be owned by user "pulsar".
dashboard_1  | This user must also own the server process.
dashboard_1  |
dashboard_1  | initdb: could not create directory "/data": Permission denied
dashboard_1  | The database cluster will be initialized with locales
dashboard_1  |   COLLATE:  C
dashboard_1  |   CTYPE:    C.UTF-8
dashboard_1  |   MESSAGES: C
dashboard_1  |   MONETARY: C
dashboard_1  |   NUMERIC:  C
dashboard_1  |   TIME:     C
dashboard_1  | The default database encoding has accordingly been set to "UTF8".
dashboard_1  | The default text search configuration will be set to "english".
dashboard_1  |
dashboard_1  | Data page checksums are disabled.
dashboard_1  |
dashboard_1  | creating directory /data/postgresql ... pg_ctl: directory "/data/postgresql" does not exist
dashboard_1  | createdb: could not connect to database template1: could not connect to server: No such file or directory
dashboard_1  | 	Is the server running locally and accepting
dashboard_1  | 	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
dashboard_1  | psql: could not connect to server: No such file or directory
dashboard_1  | 	Is the server running locally and accepting
dashboard_1  | 	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
```

### Modifications

Add a command to the entrypoint to create the data dir so the subsequent commands no longer fail

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


