### PR TITLE
Fix the pulsar-manager can not process the request by pulsar proxy

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -66,7 +66,6 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
                     && defaultEnvironmentServiceUrl.length() > 0
                     && !environmentEntityOptional.isPresent()) {
                 Map<String, String> header = Maps.newHashMap();
-                header.put("Content-Type", "application/json");
                 if (StringUtils.isNotBlank(pulsarJwtToken)) {
                     header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
                 }

--- a/src/main/java/org/apache/pulsar/manager/controller/EnvironmentsController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/EnvironmentsController.java
@@ -184,7 +184,6 @@ public class EnvironmentsController {
             return ResponseEntity.ok(result);
         }
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
@@ -219,7 +218,6 @@ public class EnvironmentsController {
             return ResponseEntity.ok(result);
         }
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BookiesServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BookiesServiceImpl.java
@@ -49,12 +49,10 @@ public class BookiesServiceImpl implements BookiesService {
     private static String pulsarJwtToken;
 
     private static final Map<String, String> header = new HashMap<String, String>(){{
-        put("Content-Type","application/json");
         put("Authorization", String.format("Bearer %s", pulsarJwtToken));
     }};
 
     private final Pattern pattern = Pattern.compile(" \\d+");;
-
     public Map<String, Object> getBookiesList(Integer pageNum, Integer pageSize, String cluster) {
         Map<String, Object> bookiesMap = Maps.newHashMap();
         List<Map<String, Object>> bookiesArray = new ArrayList<>();

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -78,9 +78,7 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
     private final ReplicationsStatsRepository replicationsStatsRepository;
     private final ConsumersStatsRepository consumersStatsRepository;
 
-    private static final Map<String, String> header = new HashMap<String, String>(){{
-        put("Content-Type","application/json");
-    }};
+    private static final Map<String, String> header = new HashMap<String, String>();
 
     @Autowired
     public BrokerStatsServiceImpl(

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokersServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokersServiceImpl.java
@@ -42,7 +42,6 @@ public class BrokersServiceImpl implements BrokersService {
         if (directRequestBroker) {
             Gson gson = new Gson();
             Map<String, String> header = Maps.newHashMap();
-            header.put("Content-Type", "application/json");
             if (StringUtils.isNotBlank(pulsarJwtToken)) {
                 header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
             }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/ClustersServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/ClustersServiceImpl.java
@@ -57,7 +57,6 @@ public class ClustersServiceImpl implements ClustersService {
         if (directRequestBroker) {
             Gson gson = new Gson();
             Map<String, String> header = Maps.newHashMap();
-            header.put("Content-Type", "application/json");
             if (StringUtils.isNotBlank(pulsarJwtToken)) {
                 header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
             }
@@ -91,7 +90,6 @@ public class ClustersServiceImpl implements ClustersService {
     public List<String> getClusterByAnyBroker(String requestHost) {
         Gson gson = new Gson();
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/EnvironmentCacheServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/EnvironmentCacheServiceImpl.java
@@ -105,7 +105,6 @@ public class EnvironmentCacheServiceImpl implements EnvironmentCacheService {
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
-        header.put("Content-Type", "application/json");
         return header;
     }
 

--- a/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/NamespacesServiceImpl.java
@@ -63,7 +63,6 @@ public class NamespacesServiceImpl implements NamespacesService {
         if (directRequestBroker) {
             Gson gson = new Gson();
             Map<String, String> header = Maps.newHashMap();
-            header.put("Content-Type", "application/json");
             if (StringUtils.isNotBlank(pulsarJwtToken)) {
                 header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
             }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/TenantsServiceImpl.java
@@ -65,7 +65,6 @@ public class TenantsServiceImpl implements TenantsService {
         if (directRequestBroker) {
             Gson gson = new Gson();
             Map<String, String> header = Maps.newHashMap();
-            header.put("Content-Type", "application/json");
             if (StringUtils.isNotBlank(pulsarJwtToken)) {
                 header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
             }

--- a/src/main/java/org/apache/pulsar/manager/service/impl/TopicsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/TopicsServiceImpl.java
@@ -199,7 +199,6 @@ public class TopicsServiceImpl implements TopicsService {
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
-        header.put("Content-Type", "application/json");
         String prefix = "/admin/v2/" + persistent + "/" + tenant + "/" + namespace;
         Gson gson = new Gson();
         String partitionedUrl = requestHost + prefix + "/partitioned";

--- a/src/test/java/org/apache/pulsar/manager/service/BrokerStatsServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/BrokerStatsServiceImplTest.java
@@ -222,7 +222,6 @@ public class BrokerStatsServiceImplTest {
     public void convertStatsToDbTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)){
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
@@ -303,7 +302,6 @@ public class BrokerStatsServiceImplTest {
     public void findByMultiTenantOrMultiNamespace() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)){
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/test/java/org/apache/pulsar/manager/service/BrokersServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/BrokersServiceImplTest.java
@@ -58,7 +58,6 @@ public class BrokersServiceImplTest {
     public void brokersServiceTest() throws Exception{
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/test/java/org/apache/pulsar/manager/service/ClustersServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/ClustersServiceImplTest.java
@@ -58,7 +58,6 @@ public class ClustersServiceImplTest {
     public void clusterServiceImplTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
@@ -87,7 +86,6 @@ public class ClustersServiceImplTest {
     public void getClusterByAnyBroker() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/test/java/org/apache/pulsar/manager/service/NamespacesServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/NamespacesServiceImplTest.java
@@ -60,7 +60,6 @@ public class NamespacesServiceImplTest {
     public void namespaceServiceImplTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
@@ -82,7 +81,6 @@ public class NamespacesServiceImplTest {
     public void getNamespaceStatsTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/test/java/org/apache/pulsar/manager/service/TenantsServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/TenantsServiceImplTest.java
@@ -63,7 +63,6 @@ public class TenantsServiceImplTest {
     public void tenantsServiceImplTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }

--- a/src/test/java/org/apache/pulsar/manager/service/TopicsServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/TopicsServiceImplTest.java
@@ -70,7 +70,6 @@ public class TopicsServiceImplTest {
     public void topicsServiceImplTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }
@@ -94,7 +93,6 @@ public class TopicsServiceImplTest {
     public void getTopicsStatsImplTest() {
         PowerMockito.mockStatic(HttpUtil.class);
         Map<String, String> header = Maps.newHashMap();
-        header.put("Content-Type", "application/json");
         if (StringUtils.isNotBlank(pulsarJwtToken)) {
             header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
         }


### PR DESCRIPTION
---

Fixes: #280 

When sending a GET request to the Pulsar proxy, the server
always threw an IllegalArgumentException. By my test that's because
we are setting the Content-Type for a request without the request body.
We remove the Content-Type if the request is GET.


