### PR TITLE
Upgrade HerdDB to 0.15.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,9 @@ dependencies {
     compile group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: springMybatisVersion
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf', version: springBootVersion
     compile group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
-    compile group: 'org.herddb', name: 'herddb-jdbc', version: herddbVersion
+    compile (group: 'org.herddb', name: 'herddb-jdbc', version: herddbVersion) {
+        exclude group: 'org.slf4j', module: 'slf4j-jdk14'
+        }
     compile group: 'javax.validation', name: 'validation-api', version: javaxValidationVersion
     compile group: 'org.hibernate', name: 'hibernate-validator', 'version': hibernateValidatorVersion
     compile group: 'io.jsonwebtoken', name: 'jjwt-api', version: jsonWebTokenApiVersion

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: springBootVersion
     compile group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: springMybatisVersion
+    compile group: 'com.github.pagehelper', name: 'pagehelper', version: pagehelperVersion
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf', version: springBootVersion
     compile group: 'org.postgresql', name: 'postgresql', version: postgresqlVersion
     compile (group: 'org.herddb', name: 'herddb-jdbc', version: herddbVersion) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # dependencies version
-springMybatisVersion=1.3.2
+springMybatisVersion=2.1.2
 javaxValidationVersion=2.0.0.Final
 hibernateValidatorVersion=6.0.13.Final
 jsonWebTokenVersion=0.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # dependencies version
 springMybatisVersion=2.1.2
+pagehelperVersion=5.1.11
 javaxValidationVersion=2.0.0.Final
 hibernateValidatorVersion=6.0.13.Final
 jsonWebTokenVersion=0.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ apiMockitoVersion=1.7.1
 mockitoJunit4Version=1.7.1
 gsonVersion=2.8.2
 postgresqlVersion=42.2.5
-herddbVersion=0.13.1
+herddbVersion=0.15.1
 brokerVersion=2.4.1
 commonsValidatorVersion=1.6


### PR DESCRIPTION
Ugrade HerdDB to 0.15.1
Release notes: https://github.com/diennea/herddb/releases/tag/v0.15.1

Most notable changes are:
- Support for Java 13
- Support for BookKeeper 4.10
- Lots of fix regarding stability and consistency in a replicated environment

Upgrade should be seamless, no data format changes on disk, new code works with old data created with 0,14, 0.13 and 0.12