### PR TITLE
Serve frontend directly from Pulsar Manager backend process

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/interceptor/AdminHandlerInterceptor.java
+++ b/src/main/java/org/apache/pulsar/manager/interceptor/AdminHandlerInterceptor.java
@@ -63,6 +63,11 @@ public class AdminHandlerInterceptor extends HandlerInterceptorAdapter {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // allow frontend requests, in case of front-end running on the same process of backend
+        if (request.getRequestURI().startsWith("/ui")
+                || request.getRequestURI().startsWith("/static")) {
+            return true;
+        }
         String token = request.getHeader("token");
         String saveToken = jwtService.getToken(request.getSession().getId());
         Map<String, Object> map = Maps.newHashMap();


### PR DESCRIPTION
Fixes #269 

### Motivation

Use the Tomcat Service provided by StringBoot Application to serve front-end resources.
This way in order to start a pulsar manager instance you only have to run bin/pulsar-manager
and you are able to access the UI with
https://localhost:7750/ui

### Modifications

Assume that the frontend is inside directory "ui" of pulsar manager dist package.
Deploy such static content using SpringBootMVC standard components.

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.
- Run Pulsar Manager standalone and use the frontend at https://localhost:7750/ui/index.html
 


