### PR TITLE
Using volumes instead of binding mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ is able to talk to the brokers and bookies in your Pulsar cluster.
     docker run -d -it \
         -p 6650:6650 \
         -p 8080:8080 \
-        -v $PWD/data:/pulsar/data \
+        -v pulsardata:/pulsar/data \
+        -v pulsarconf:/pulsar/conf \
         --name pulsar-standalone \
         apachepulsar/pulsar:latest \
         bin/pulsar standalone
@@ -48,7 +49,7 @@ is able to talk to the brokers and bookies in your Pulsar cluster.
         -e USERNAME=pulsar \
         -e PASSWORD=pulsar \
         -e LOG_LEVEL=DEBUG \
-        -v $PWD:/data \
+        -v pulsarui:/data \
         --link pulsar-standalone \
         apachepulsar/pulsar-manager:v0.1.0
     ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ is able to talk to the brokers and bookies in your Pulsar cluster.
     * `PASSWORD`: the password of PostgreSQL.
 
     * `LOG_LEVEL`: level of log.
-
+    
+    * `pulsarui` : docker volume to store PostgresSQL data.
 
 ### Use Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ is able to talk to the brokers and bookies in your Pulsar cluster.
 
     * `LOG_LEVEL`: level of log.
     
-    * `pulsarui` : docker volume to store PostgresSQL data.
+    * `pulsarui`: docker volume to store PostgresSQL data.
 
 ### Use Docker Compose
 


### PR DESCRIPTION
### Motivation

Docker volumes are better than binding mounts.

### Modifications  

Change install through docker docs

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


