### PR TITLE
Support multi address for broker stats

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -131,7 +131,12 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
             clusterLists.forEach((clusterMap) -> {
                 String cluster = (String) clusterMap.get("cluster");
                 Pair<String, String> envCluster = Pair.of(env.getName(), cluster);
-                collectStatsServiceUrls.put(envCluster, (String) clusterMap.get("serviceUrl"));
+                String webServiceUrl = (String) clusterMap.get("serviceUrl");
+                if (webServiceUrl.contains(",")) {
+                    String[] webServiceUrlList = webServiceUrl.split(",");
+                    webServiceUrl = webServiceUrlList[0];
+                }
+                collectStatsServiceUrls.put(envCluster, webServiceUrl);
             });
         }
         collectStatsServiceUrls.forEach((envCluster, serviceUrl) -> {

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -142,7 +142,7 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
                         if (!url.contains("http://")) {
                             url = "http://" + url;
                         }
-                        String httpTestResult = HttpUtil.doGet( url + "/metrics", header);
+                        String httpTestResult = HttpUtil.doGet( url + "/admin/v2/brokers/health", header);
                         if (httpTestResult == null) {
                             log.error("This service {} is down, please check", url);
                         } else {

--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -134,7 +135,21 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
                 String webServiceUrl = (String) clusterMap.get("serviceUrl");
                 if (webServiceUrl.contains(",")) {
                     String[] webServiceUrlList = webServiceUrl.split(",");
-                    webServiceUrl = webServiceUrlList[0];
+                    if (StringUtils.isNotBlank(pulsarJwtToken)) {
+                        header.put("Authorization", String.format("Bearer %s", pulsarJwtToken));
+                    }
+                    for (String url : webServiceUrlList) {
+                        if (!url.contains("http://")) {
+                            url = "http://" + url;
+                        }
+                        String httpTestResult = HttpUtil.doGet( url + "/metrics", header);
+                        if (httpTestResult == null) {
+                            log.error("This service {} is down, please check", url);
+                        } else {
+                            webServiceUrl = url;
+                            break;
+                        }
+                    }
                 }
                 collectStatsServiceUrls.put(envCluster, webServiceUrl);
             });


### PR DESCRIPTION



### Motivation

When the cluster is configured with multiple service addresses, the web service URL will be parsed incorrectly

### Modifications

* Support multi-address for broker stats collect metrics.




