### PR TITLE
Remove unused fields in BrokerStatsServiceImpl

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/BrokerStatsServiceImpl.java
@@ -66,9 +66,6 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
     @Value("${backend.directRequestHost}")
     private String directRequestHost;
 
-    @Value("${backend.jwt.token}")
-    private String pulsarJwtToken;
-
     @Value("${clear.stats.interval}")
     private Long clearStatsInterval;
 
@@ -81,8 +78,6 @@ public class BrokerStatsServiceImpl implements BrokerStatsService {
     private final ReplicationsStatsRepository replicationsStatsRepository;
     private final ConsumersStatsRepository consumersStatsRepository;
     private final PulsarAdminService pulsarAdminService;
-
-    private static final Map<String, String> header = new HashMap<>();
 
     @Autowired
     public BrokerStatsServiceImpl(


### PR DESCRIPTION
Master Issue: #249

### Motivation

See #249.

### Modifications

Fix to use PulsarAdmin in BrokerStatsServiceImpl.
(Remove fields which is no longer used due to #315.)

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.