### PR TITLE
Add gradle tasks to build front-end

### DIFF
--- a/front-end/build.gradle
+++ b/front-end/build.gradle
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath 'com.moowork.gradle:gradle-node-plugin:1.2.0'
+    }
+}
+apply plugin: 'base'
+apply plugin: 'com.moowork.node' // gradle-node-plugin
+
+node {
+    /* gradle-node-plugin configuration
+       https://github.com/srs/gradle-node-plugin/blob/master/docs/node.md
+       Task name pattern:
+       ./gradlew npm_<command> Executes an NPM command.
+    */
+    // Version of node to use.
+    version = '10.14.1'
+    // Version of npm to use.
+    npmVersion = '6.4.1'
+    // If true, it will download node using above parameters.
+    // If false, it will try to use globally installed node.
+    download = true
+}
+
+npm_run_build {
+ // disable default 'npm run build' as we need 'npm run build:prod'
+ enabled = false
+}
+
+task npmBuildProd(type: NpmTask) {
+  args = ['run', 'build:prod']
+}
+
+
+assemble.dependsOn npm_run_build
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+include 'front-end'
+


### PR DESCRIPTION
Add Gradle build files to front-end directory in order to allow front-end to be simply built using gradle.

With this change you can simply run:
` ./gradlew front-end:npmInstall front-end:npmBuildProd build -x test`

Summary of changes:
- add new build.gradle to 'front-end'
- link 'front-end' in settings.gradle
- configured gradle node plugin in order to run 'npm install' and 'npm run build:prod'

This is a preparatory task to help bundling the front-end build distribution in the release pulsar-manager tarball automatically (see #288 )

