### PR TITLE
Upgrade BKVM to 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,6 @@ postgresqlVersion=42.2.5
 herddbVersion=0.19.0
 brokerVersion=2.4.1
 commonsValidatorVersion=1.6
-bkvmVersion=1.2.0
+bkvmVersion=2.0.0
 tomcatVersion=8.5.31
 jerseyVersion=2.26


### PR DESCRIPTION
### Motivation

BKVM 2.0.0 introduced a few bug fixes and especially it is now able to boot even if the BookKeeper/ZooKeeper cluster is not available (priming ZooKeeper connection is deferred to a separate background task)

### Modifications

Update BKVM to 2.0.0

### Verifying this change

- [X] Make sure that the change passes the `./gradlew build` checks.
- verify that BKVM is working


