### PR TITLE
create /data dir

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,6 +27,7 @@ addgroup pulsar
 adduser --disabled-password --ingroup pulsar pulsar
 mkdir -p /run/postgresql
 chown -R pulsar:pulsar /run/postgresql/
+mkdir -p /data
 chown -R pulsar:pulsar /data
 chown pulsar:pulsar /pulsar-manager/init_db.sql
 chmod 750 /data


### PR DESCRIPTION
Fixes #336

### Motivation
there is no `/data/` directory in a docker container, which caught #336 error.
### Verifying this change

- [√] Make sure that the change passes the `./gradlew build` checks.
