### PR TITLE
optimize default docker image for beginners

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,10 @@ FROM openjdk:8-jre-alpine
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
+# use default configuration file
+ENV SPRING_CONFIGURATION_FILE=/pulsar-manager/pulsar-manager/application.properties
+# use default PostGreSQL Server
+ENV URL="jdbc:postgresql://127.0.0.1:5432/pulsar_manager"
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="Apache Pulsar Manager" \
       org.label-schema.description="An Apache Pulsar Manager for management Pulsar clusters" \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,21 +18,20 @@
 # under the License.
 #
 
-
-if [[ "$URL" = "jdbc:postgresql://127.0.0.1:5432/pulsar_manager" ]]
-then
-echo 'Starting PostGreSQL Server'
-
+# add user
 addgroup pulsar
 adduser --disabled-password --ingroup pulsar pulsar
-mkdir -p /run/postgresql
-chown -R pulsar:pulsar /run/postgresql/
-mkdir -p /data
-chown -R pulsar:pulsar /data
-chown pulsar:pulsar /pulsar-manager/init_db.sql
-chmod 750 /data
-
-su - pulsar -s /bin/sh /pulsar-manager/startup.sh
+# init PostGreSQL Server
+if [[ "$URL" = "jdbc:postgresql://127.0.0.1:5432/pulsar_manager" ]]
+then
+  echo 'Starting PostGreSQL Server'
+  mkdir -p /run/postgresql
+  chown -R pulsar:pulsar /run/postgresql/
+  mkdir -p /data
+  chown -R pulsar:pulsar /data
+  chown pulsar:pulsar /pulsar-manager/init_db.sql
+  chmod 750 /data
+  su - pulsar -s /bin/sh /pulsar-manager/startup.sh
 fi
 
 echo 'Starting Pulsar Manager Front end'

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -29,4 +29,4 @@ minprocs=200
 
 [program:pulsar-manager-backend]
 command = /pulsar-manager/pulsar-manager/bin/pulsar-manager  --redirect.host=%(ENV_REDIRECT_HOST)s --redirect.port=%(ENV_REDIRECT_PORT)s --spring.datasource.driver-class-name=%(ENV_DRIVER_CLASS_NAME)s --spring.datasource.url=%(ENV_URL)s --spring.datasource.username=%(ENV_USERNAME)s --spring.datasource.password=%(ENV_PASSWORD)s --spring.datasource.initialization-mode=never --logging.level.org.apache=%(ENV_LOG_LEVEL)s
-user = root 
+user = pulsar

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,7 +88,7 @@ jwt.sessionTime=2592000
 pulsar-manager.account=pulsar
 pulsar-manager.password=pulsar
 # If true, the database is used for user management
-user.management.enable=true
+user.management.enable=false
 
 # Optional -> SECRET, PRIVATE, default -> PRIVATE, empty -> disable auth
 # SECRET mode -> bin/pulsar tokens create --secret-key file:///path/to/my-secret.key --subject test-user


### PR DESCRIPTION
Fixes #367

### Motivation
optimize default docker image for beginners

### Modifications
1, add default value for ` SPRING_CONFIGURATION_FILE` and `URL` environment.
2, set `user.management.enable` default `false` for login using `pulsar/pulsar` account.
3, `supervisord` use `pulsar` user.
4, indent error.
### Verifying this change

- [√] Make sure that the change passes the `./gradlew build` checks.


