### PR TITLE
Upgrade Athenz version and remove yahoo.bintray.com repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
-    maven {
-        url "https://yahoo.bintray.com/maven"
-    }
 }
 
 configurations {
@@ -125,6 +122,7 @@ dependencies {
     compile group: 'org.apache.pulsar', name: 'pulsar-client-admin-original', version: pulsarVersion
     compile group: 'org.apache.pulsar', name: 'pulsar-client-auth-athenz', version: pulsarVersion
     compile group: 'org.apache.pulsar', name: 'pulsar-client-auth-sasl', version: pulsarVersion
+    compile group: 'com.yahoo.athenz', name: 'athenz-zts-java-client', version: athenzVersion
     compile group: 'io.springfox', name: 'springfox-swagger2', version: swagger2Version
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: swaggeruiVersion
     compile group: 'org.apache.pulsar', name: 'pulsar-broker', version: pulsarVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ pageHelperVersion=1.2.4
 mockitoVersion=2.8.47
 guavaVersion=21.0
 pulsarVersion=2.7.0
+athenzVersion=1.10.9
 swagger2Version=2.9.2
 swaggeruiVersion=2.9.2
 apiMockitoVersion=1.7.1


### PR DESCRIPTION
### Motivation

The `yahoo.bintray.com` repository will be shut down on May 1st. So we need to get the Athenz library from the Maven Central repository instead of `yahoo.bintray.com`, but the version of the library currently used by Pulsar Manager does not exist on Maven Central. 

### Modifications

- Upgrade Athenz to 1.10.9
- Remove the `yahoo.bintray.com` repository from `build.grade`

Related: https://github.com/apache/pulsar/pull/10079

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


