### PR TITLE
Use the Apache Pulsar Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ Alternatively, you can start a standalone and Pulsar Manager using the docker co
 
 ### Deploy Pulsar Manager to Kubernetes
 
-The Pulsar Manager can be deployed as part of [Pulsar Helm Chart](https://github.com/streamnative/charts).
+The Pulsar Manager can be deployed as part of [Pulsar Helm Chart](https://github.com/apache/pulsar-helm-chart).
 
 1. Install the Pulsar cluster with Pulsar Manager
 
     ```bash
-    helm repo add streamnative https://charts.streamnative.io
+    helm repo add apache https://pulsar.apache.org/charts
     helm repo update
-    helm install <release-name> streamnative/pulsar
+    helm install <release-name> apache/pulsar
     ```
 
 2. Access the Pulsar Manager.


### PR DESCRIPTION
### Motivation

In reading through the `pulsar-manager` documentation, I noticed that the README points to the StreamNative helm chart. I believe this is likely because the StreamNative helm chart predated the Apache one. I'm unfamiliar with the differences between these two charts, but I would think that this project should point to the official Apache Pulsar helm chart. If that assumption is wrong, please let me know.

### Modifications

Reference the official Apache Pulsar Helm chart, instead.

### Verifying this change

Followed the directions in https://github.com/apache/pulsar-helm-chart, which are pretty much the same as https://github.com/streamnative/charts.