### PR TITLE
fix ISSUE-390: Pulsar manager successfully added the administrator account with password "admin", but the web login password can not be less than 6 digits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ After running these steps, the Pulsar Manager is running locally at http://127.0
     ```
 
     * `backend-service`: The IP address or domain name of the backend service.
+    * `password`: The password should be more than or equal to 6 digits.
 
 2. Create an environment. 
 


### PR DESCRIPTION
Fixes #390 

### Motivation

in index.vue, there's a password length validation for login: 
the password can not be less than 6 digits.
![image](https://user-images.githubusercontent.com/5304046/119593020-12d89180-be0c-11eb-84cf-f641d8c27fc0.png)

so, in README.md, when create a super-user using command, should have some relevant instructions.

### Modifications

I modified the README.md.

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


