### PR TITLE
Avoid conflict between user management and default admin account

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,7 +88,7 @@ jwt.sessionTime=2592000
 pulsar-manager.account=pulsar
 pulsar-manager.password=pulsar
 # If true, the database is used for user management
-user.management.enable=true
+user.management.enable=false
 
 # Optional -> SECRET, PRIVATE, default -> PRIVATE, empty -> disable auth
 # SECRET mode -> bin/pulsar tokens create --secret-key file:///path/to/my-secret.key --subject test-user


### PR DESCRIPTION
Fixes #382 

### Motivation

I also cannot log in with the default admin account on Pulsar-Manager 0.2.0. Just realized that we have two conflicted configs in the `application.properties`. And this properties file is used as the default configs in the archived `pulsar-manager.jar`.

```
# If user.management.enable is true, the following account and password will no longer be valid.
pulsar-manager.account=pulsar
pulsar-manager.password=pulsar
# If true, the database is used for user management
user.management.enable=true
```


### Modifications

I just set `user.management.enable` to `false` so we use the default admin account as the default approach.

### Verifying this change

This fixed is very minor and I have all the builts are successful


