### PR TITLE
Fixed the bug that admin roles cannot be deleted.

### DIFF
--- a/front-end/src/views/management/tenants/tenant.vue
+++ b/front-end/src/views/management/tenants/tenant.vue
@@ -254,6 +254,7 @@ export default {
       this.dynamicRoles.splice(this.dynamicRoles.indexOf(tag), 1)
       const data = {}
       data.adminRoles = this.dynamicRoles
+      data.allowedClusters = this.clusterValue
       updateTenant(this.postForm.tenant, data).then(() => {
         this.$notify({
           title: 'success',


### PR DESCRIPTION

### Motivation

When I try to close a admin role under a cluster, it prompts me that 'Clusters can not be empty'.  I found out that it was because the frontend did not pass the allowed clusters to the backend. 

### Modifications

 I added a line of code to pass the missing parameters to the backend.
