### PR TITLE
Upgrade to java 1.8.0_292

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/build/distributions/pulsar-manager.tar
+!/docker
+!/front-end/dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -31,13 +31,11 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-RUN apk update
+RUN apt-get update
 
-RUN apk add nginx \
-  && apk add supervisor \
-  && apk add postgresql \
+RUN apt-get install --yes nginx supervisor postgresql \
   && rm  -rf /tmp/* \
-  && rm /var/cache/apk/*
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /run/nginx
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
### Motivation

The version of java in `openjdk:jre-8-alpine` has multiple security
vulnerabilities, and has not been updated in over 2 years.

### Modifications

This switches to the `openjdk:jre-8` image. This image is updated
more frequently (last update 7 days ago at time of writing).

Successfully built from my box using:

```
sudo docker build -f docker/Dockerfile -t apachepulsar/pulsar-manager:v0.3.0 .
```

I also confirmed the image works by using the existing `docker-compose.yml` with the image tag
changed to `v0.3.0` after the build command above. I was able to set an admin password and
log into the dashboard without issue.

The addition of `.dockerignore` reduces the time it takes for  "Sending build context to Docker daemon" to complete while building.

### Verifying this change

- [ ] Make sure that the change passes the `./gradlew build` checks.


