### PR TITLE
The password can not be less than 6 digits

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/service/impl/UsersServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/UsersServiceImpl.java
@@ -52,6 +52,10 @@ public class UsersServiceImpl implements UsersService {
             validateResult.put("error", "Fields password and access token cannot be empty at the same time.");
             return validateResult;
         }
+        if (userInfoEntity.getPassword().length() < 6) {
+            validateResult.put("error", "The password can not be less than 6 digits.");
+            return validateResult;
+        }
         validateResult.put("message", "Validate user success");
         return validateResult;
     }


### PR DESCRIPTION
Fixes #413 

Master Issue: #413 

Describe the modifications you've done.

When adding users to the /users/superuser interface, you need to add a password that is not less than 6 digits for verification, otherwise you cannot log in with a password less than 6 digits