### PR TITLE
Create Index on topics_stats to fix tenants tab latency

### DIFF
--- a/src/main/resources/META-INF/sql/postgresql-schema.sql
+++ b/src/main/resources/META-INF/sql/postgresql-schema.sql
@@ -45,6 +45,8 @@ CREATE TABLE IF NOT EXISTS topics_stats (
   time_stamp BIGINT
 );
 
+CREATE INDEX IF NOT EXISTS ix_topics_stats_timestamp on topics_stats(time_stamp);
+
 CREATE TABLE IF NOT EXISTS publishers_stats (
   publisher_stats_id BIGSERIAL PRIMARY KEY,
   producer_id BIGINT,


### PR DESCRIPTION


Fixes #419

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Tenants tab in Pulsar Manager is slow and takes forever to load sometime.

### Modifications
We are using Postgres for data storage and noticed that while loading tenants page it is stuck at one query and takes forever to load. Tenants page request load data from topics_stats table and load only one topic status with latest timestamp. The query used here https://github.com/sourabhaggrawal/pulsar-manager/blob/5343f09f381729ef6798ddf1bffccd55aaff04b8/src/main/java/com/manager/pulsar/mapper/TopicsStatsMapper.java#L37 fetch only single record by ordering on the timestamp column everytime, with too many records this query takes too much time .

Added the index to get result faster from the query.
### Verifying this change
- [x] Make sure that the change passes the `./gradlew build` checks.


