### PR TITLE
Allow user to assign tenant as resource to role

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/controller/TenantsController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/TenantsController.java
@@ -124,7 +124,9 @@ public class TenantsController {
                 List<RoleInfoEntity> roleInfoEntities = rolesRepository.findAllRolesByMultiId(roleIdList);
                 List<Long> tenantsIdList = new ArrayList<>();
                 for (RoleInfoEntity roleInfoEntity : roleInfoEntities) {
-                    tenantsIdList.add(roleInfoEntity.getResourceId());
+                    if(roleInfoEntity.getResourceType().equals(ResourceType.TENANTS.name())) {
+                        tenantsIdList.add(roleInfoEntity.getResourceId());
+                    }
                 }
                 if (!tenantsIdList.isEmpty()) {
                     tenantEntities = tenantsRepository.findByMultiId(tenantsIdList);

--- a/src/main/java/org/apache/pulsar/manager/dao/TenantsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/TenantsRepositoryImpl.java
@@ -79,4 +79,9 @@ public class TenantsRepositoryImpl implements TenantsRepository {
         tenantsMapper.delete(tenant);
     }
 
+    @Override
+    public List<TenantEntity> findByEnvironment(String environment) {
+        return tenantsMapper.findAll(environment);
+    }
+
 }

--- a/src/main/java/org/apache/pulsar/manager/entity/TenantsRepository.java
+++ b/src/main/java/org/apache/pulsar/manager/entity/TenantsRepository.java
@@ -38,5 +38,7 @@ public interface TenantsRepository {
 
     void remove(String tenant);
 
+    List<TenantEntity> findByEnvironment(String environment);
+
 }
 

--- a/src/main/java/org/apache/pulsar/manager/mapper/TenantsMapper.java
+++ b/src/main/java/org/apache/pulsar/manager/mapper/TenantsMapper.java
@@ -77,4 +77,8 @@ public interface TenantsMapper {
     @Delete("DELETE FROM tenants WHERE tenant = #{tenant}")
     void delete(String tenant);
 
+    @Select("SELECT tenant, tenant_id as tenantId, admin_roles as adminRoles,allowed_clusters as allowedClusters," +
+            "environment_name as environmentName " +
+            "FROM tenants WHERE environment_name = #{environment}")
+    List<TenantEntity> findAll(String environment);
 }

--- a/src/test/java/org/apache/pulsar/manager/dao/TenantsRepositoryImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/dao/TenantsRepositoryImplTest.java
@@ -129,4 +129,20 @@ public class TenantsRepositoryImplTest {
         Assert.assertEquals("test-cluster", getTenantEntity.getAllowedClusters());
         Assert.assertEquals("test-environment", getTenantEntity.getEnvironmentName());
     }
+
+    @Test
+    public void findByEnvironment() {
+        TenantEntity tenantEntity = new TenantEntity();
+        tenantEntity.setTenant("test");
+        tenantEntity.setAdminRoles("test-role");
+        tenantEntity.setAllowedClusters("test-cluster");
+        tenantEntity.setEnvironmentName("test-environment");
+        long tenantId = tenantsRepository.save(tenantEntity);
+        List<TenantEntity> result = tenantsRepository.findByEnvironment("test-environment");
+        TenantEntity getTenantEntity = result.get(0);
+        Assert.assertEquals("test", getTenantEntity.getTenant());
+        Assert.assertEquals("test-role", getTenantEntity.getAdminRoles());
+        Assert.assertEquals("test-cluster", getTenantEntity.getAllowedClusters());
+        Assert.assertEquals("test-environment", getTenantEntity.getEnvironmentName());
+    }
 }


### PR DESCRIPTION
### Motivation
Improve Tenant/Namespace resource assignment workflow.
 
* When assigning the resource to a role, it only let you choose from Namespace,SCHEMA,Functions but does not allow the user to select TENANT. A user should have ability to choose tenant for a role and assign the role to a user. Based on which the user should be able to see the tenant it is assigned with. 


### Modifications

* changes in this PR include below fixes.
1. Add TENANT as ResourceType along with Namepsace,Schema etc for Create/Edit Role.
2. Include only tenants as resource while preparing the response from api /tenants in TenantsController.
3. In Success LoginResponse, add the tenant as header which is assigned to user's role instead of tenant with user's name.

### Verifying this change

- [ ] Make sure that the change passes the `./gradlew build` checks.


