### PR TITLE
Set read/write access to resource for each role

### DIFF
--- a/front-end/src/store/modules/user.js
+++ b/front-end/src/store/modules/user.js
@@ -20,6 +20,22 @@ import { Message } from 'element-ui'
 import { setTenant, removeTenant } from '../../utils/tenant'
 import { getUserInfo } from '@/api/users'
 
+export function hasPermissionToResource(resourceType, resourceName, permission) {
+  if (isSuperAdmin(user)) { // Super admin will have access to everything
+    return true
+  }
+  if (user.state.access.hasOwnProperty(resourceType)) {
+    if (user.state.access[resourceType].hasOwnProperty(resourceName)) {
+      return user.state.access[resourceType][resourceName] === permission
+    }
+  }
+  return false
+}
+
+export function isSuperAdmin(user) {
+  return user.state.roles.indexOf('super') != -1
+}
+
 const user = {
   state: {
     user: '',
@@ -32,6 +48,9 @@ const user = {
     roles: [],
     setting: {
       articlePlatform: []
+    },
+    access: {
+
     }
   },
 
@@ -59,7 +78,11 @@ const user = {
     },
     SET_ROLES: (state, roles) => {
       state.roles = roles
+    },
+    SET_ACCESS: (state, access) => {
+      state.access = access
     }
+
   },
 
   actions: {
@@ -93,6 +116,7 @@ const user = {
           commit('SET_ROLES', response.data.roles)
           commit('SET_NAME', 'admin')
           commit('SET_INTRODUCTION', 'Pulsar Manager')
+          commit('SET_ACCESS', response.data.access)
           resolve(response)
         })
       })
@@ -104,6 +128,7 @@ const user = {
         logout(state.token).then(() => {
           commit('SET_TOKEN', '')
           commit('SET_ROLES', [])
+          commit('SET_ACCESS', {})
           removeToken()
           removeCsrfToken()
           removeName()

--- a/front-end/src/views/management/admin/tenants/tenant.vue
+++ b/front-end/src/views/management/admin/tenants/tenant.vue
@@ -33,7 +33,7 @@
             style="width: 200px;"
             @keyup.enter.native="handleFilterNamespace"/>
           <el-button type="primary" icon="el-icon-search" @click="handleFilterNamespace"/>
-          <el-button type="primary" icon="el-icon-plus" @click="handleCreateNamespace">{{ $t('namespace.newNamespace') }}</el-button>
+          <el-button v-if="hasAccess(postForm.tenant,'write')" type="primary" icon="el-icon-plus" @click="handleCreateNamespace">{{ $t('namespace.newNamespace') }}</el-button>
         </div>
         <el-row :gutter="24">
           <el-col :xs="{span: 24}" :sm="{span: 24}" :md="{span: 24}" :lg="{span: 24}" :xl="{span: 24}">
@@ -59,7 +59,7 @@
                   </router-link>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
+              <el-table-column v-if="hasAccess(postForm.tenant,'write')" :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
                 <template slot-scope="scope">
                   <router-link :to="'/management/namespaces/' + scope.row.tenant +'/' + scope.row.namespace + '/namespace'">
                     <el-button type="primary" size="mini">{{ $t('table.edit') }}</el-button>
@@ -101,6 +101,7 @@ import {
   deleteNamespace
 } from '@/api/namespaces'
 import { validateEmpty } from '@/utils/validate'
+import { hasPermissionToResource } from '../../../../store/modules/user'
 
 const defaultForm = {
   tenant: getTenant()
@@ -243,6 +244,9 @@ export default {
         this.listNamespaces = []
         this.getNamespacesList()
       })
+    },
+    hasAccess(tenant, permission) {
+      return hasPermissionToResource('TENANTS', tenant, permission)
     }
   }
 }

--- a/front-end/src/views/management/namespaces/namespace.vue
+++ b/front-end/src/views/management/namespaces/namespace.vue
@@ -1,4 +1,5 @@
 <!--
+<!--
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -61,8 +62,8 @@
         <el-tabs v-model="activeBundleCluster" type="border-card" @tab-click="handleBundleTabClick">
           <el-tab-pane v-for="(item,index) in replicationClustersValue" :key="item+index" :label="item" :name="item">
             <div class="filter-container">
-              <el-button class="filter-item" style="margin-left: 10px;" type="danger" icon="el-icon-download" @click="handleUnloadAll">Unload All</el-button>
-              <el-button class="filter-item" style="margin-left: 10px;" type="danger" icon="el-icon-close" @click="hanldeClearAllBacklog">Clear All Backlog</el-button>
+              <el-button v-if="hasAccess(postForm.namespace,'write')" class="filter-item" style="margin-left: 10px;" type="danger" icon="el-icon-download" @click="handleUnloadAll">Unload All</el-button>
+              <el-button v-if="hasAccess(postForm.namespace,'write')" class="filter-item" style="margin-left: 10px;" type="danger" icon="el-icon-close" @click="hanldeClearAllBacklog">Clear All Backlog</el-button>
             </div>
             <el-table
               :key="tableKey"
@@ -76,7 +77,7 @@
                   <span>{{ scope.row.bundle }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('namespace.bundle.operation')" align="center" class-name="small-padding fixed-width">
+              <el-table-column v-if="hasAccess(postForm.namespace,'write')" :label="$t('namespace.bundle.operation')" align="center" class-name="small-padding fixed-width">
                 <template slot-scope="scope">
                   <el-button size="medium" style="margin-left: 10px;" type="danger" icon="el-icon-share" @click="handleSplitBundle(scope.row)">{{ $t('namespace.bundle.split') }}</el-button>
                   <el-button size="medium" style="margin-left: 10px;" type="danger" icon="el-icon-download" @click="handleUnloadBundle(scope.row)">{{ $t('namespace.bundle.unload') }}</el-button>
@@ -92,7 +93,7 @@
       <el-tab-pane :label="$t('tabs.topic')" name="topics">
         <el-input v-model="searchTopic" :placeholder="$t('namespace.searchTopics')" style="width: 200px;" @keyup.enter.native="handleFilterTopic"/>
         <el-button type="primary" icon="el-icon-search" @click="handleFilterTopic"/>
-        <el-button type="primary" icon="el-icon-plus" @click="handleCreateTopic">{{ $t('namespace.newTopic') }}</el-button>
+        <el-button v-if="hasAccess(postForm.namespace,'write')" type="primary" icon="el-icon-plus" @click="handleCreateTopic" >{{ $t('namespace.newTopic') }}</el-button>
         <el-row :gutter="24">
           <el-col :xs="{span: 24}" :sm="{span: 24}" :md="{span: 24}" :lg="{span: 24}" :xl="{span: 24}" style="margin-top:15px">
             <el-table
@@ -159,7 +160,7 @@
           </el-col>
         </el-row>
       </el-tab-pane>
-      <el-tab-pane :label="$t('tabs.policies')" name="policies">
+      <el-tab-pane v-if="hasAccess(postForm.namespace,'write')" :label="$t('tabs.policies')" name="policies" >
         <h4>{{ $t('namespace.policy.cluster') }}</h4>
         <hr class="split-line">
         <div class="component-item">
@@ -208,7 +209,7 @@
                 :value="item.value"
                 style="width:300px"/>
             </el-select>
-            <el-button @click.prevent="handleClose(tag)">{{ $t('namespace.policy.deleteRole') }}</el-button>
+            <el-button v-if="hasAccess(postForm.namespace,'write')" @click.prevent="handleClose(tag)">{{ $t('namespace.policy.deleteRole') }}</el-button>
           </el-tag>
           <el-form-item style="margin-top:30px">
             <el-input
@@ -756,6 +757,7 @@ import MdInput from '@/components/MDinput'
 import { validateEmpty } from '@/utils/validate'
 import { formatBytes } from '@/utils/index'
 import { numberFormatter } from '@/filters/index'
+import { hasPermissionToResource } from '../../../store/modules/user'
 
 const defaultForm = {
   tenant: '',
@@ -1663,6 +1665,9 @@ export default {
           }
         }
       })
+    },
+    hasAccess(namespace, permission) {
+      return hasPermissionToResource('NAMESPACES', namespace, permission)
     }
   }
 }

--- a/front-end/src/views/management/tenants/tenant.vue
+++ b/front-end/src/views/management/tenants/tenant.vue
@@ -33,7 +33,7 @@
             style="width: 200px;"
             @keyup.enter.native="handleFilterNamespace"/>
           <el-button type="primary" icon="el-icon-search" @click="handleFilterNamespace"/>
-          <el-button type="primary" icon="el-icon-plus" @click="handleCreateNamespace">{{ $t('namespace.newNamespace') }}</el-button>
+          <el-button v-if="hasAccess(postForm.tenant,'write')" type="primary" icon="el-icon-plus" @click="handleCreateNamespace">{{ $t('namespace.newNamespace') }}</el-button>
         </div>
         <el-row :gutter="24">
           <el-col :xs="{span: 24}" :sm="{span: 24}" :md="{span: 24}" :lg="{span: 24}" :xl="{span: 24}">
@@ -84,7 +84,7 @@
                   <span>{{ scope.row.storageSize }}</span>
                 </template>
               </el-table-column>
-              <el-table-column :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
+              <el-table-column v-if="hasAccess(postForm.tenant,'write')" :label="$t('table.actions')" align="center" class-name="small-padding fixed-width">
                 <template slot-scope="scope">
                   <router-link :to="'/management/namespaces/' + scope.row.tenant +'/' + scope.row.namespace + '/namespace'">
                     <el-button type="primary" size="mini">{{ $t('table.edit') }}</el-button>
@@ -186,7 +186,7 @@ import {
 import { validateEmpty } from '@/utils/validate'
 import { formatBytes } from '@/utils/index'
 import { numberFormatter } from '@/filters/index'
-
+import { hasPermissionToResource } from '../../../store/modules/user'
 const defaultForm = {
   tenant: ''
 }
@@ -456,6 +456,9 @@ export default {
         this.listNamespaces = []
         this.getNamespacesList()
       })
+    },
+    hasAccess(tenant, permission) {
+      return hasPermissionToResource('TENANTS', tenant, permission)
     }
   }
 }

--- a/front-end/src/views/management/topics/partitionedTopic.vue
+++ b/front-end/src/views/management/topics/partitionedTopic.vue
@@ -68,6 +68,7 @@
         </el-table>
         <h4>{{ $t('topic.subscription.subscriptions') }}</h4>
         <el-button
+          v-if="hasAccess(postForm.namespace,'write')"
           class="filter-item"
           type="success"
           style="margin-bottom: 15px"
@@ -217,7 +218,7 @@
           </el-col>
         </el-row>
       </el-tab-pane>
-      <el-tab-pane label="POLICIES" name="policies">
+      <el-tab-pane v-if="hasAccess(postForm.namespace,'write')" label="POLICIES" name="policies">
         <h4>{{ $t('topic.policy.authentication') }}
           <el-tooltip :content="authorizationContent" class="item" effect="dark" placement="top">
             <i class="el-icon-info"/>
@@ -325,6 +326,7 @@ import Pagination from '@/components/Pagination' // Secondary package based on e
 import { formatBytes } from '@/utils/index'
 import { numberFormatter } from '@/filters/index'
 import { putSubscriptionOnCluster, deleteSubscriptionOnCluster } from '@/api/subscriptions'
+import { hasPermissionToResource } from '../../../store/modules/user'
 
 const defaultForm = {
   persistent: '',
@@ -798,6 +800,9 @@ export default {
       } else {
         sessionStorage.removeItem('refreshInterval')
       }
+    },
+    hasAccess(namespace, permission) {
+      return hasPermissionToResource('NAMESPACES', namespace, permission)
     }
   }
 }

--- a/front-end/src/views/management/topics/topic.vue
+++ b/front-end/src/views/management/topics/topic.vue
@@ -64,6 +64,7 @@
                 <el-table-column :label="$t('topic.data')" prop="data"/>
               </el-table>
               <el-button
+                v-if="hasAccess(postForm.namespace,'write')"
                 class="filter-item"
                 type="danger"
                 style="margin-top:15px;"
@@ -96,7 +97,7 @@
                 type="primary"
                 style="display:block;margin-top:15px;margin-left:auto;margin-right:auto;"
                 icon="el-icon-close"
-                @click="handleTerminate">
+                @click="handleTerminate" >
                 {{ $t('topic.terminate') }}
               </el-button>
               <el-button
@@ -105,7 +106,7 @@
                 style="display:block;margin-top:15px;margin-left:auto;margin-right:auto;"
                 icon="el-icon-close"
                 disabled
-                @click="handleTerminate">
+                @click="handleTerminate" >
                 {{ $t('topic.terminate') }}
               </el-button>
             </el-card>
@@ -271,6 +272,7 @@
         </el-row>
         <h4>{{ $t('topic.subscription.subscriptions') }}</h4>
         <el-button
+          v-if="hasAccess(postForm.namespace,'write')"
           class="filter-item"
           type="success"
           style="margin-bottom: 15px"
@@ -461,7 +463,7 @@
           </el-col>
         </el-row>
       </el-tab-pane>
-      <el-tab-pane :label="$t('tabs.policies')" name="policies">
+      <el-tab-pane v-if="hasAccess(postForm.namespace,'write')" :label="$t('tabs.policies')" name="policies">
         <h4>{{ $t('topic.policy.authentication') }}
           <el-tooltip :content="authorizationContent" class="item" effect="dark" placement="top">
             <i class="el-icon-info"/>
@@ -561,6 +563,7 @@ import { formatBytes } from '@/utils/index'
 import { numberFormatter } from '@/filters/index'
 import { putSubscriptionOnCluster, deleteSubscriptionOnCluster } from '@/api/subscriptions'
 import { validateSizeString } from '@/utils/validate'
+import { hasPermissionToResource } from '../../../store/modules/user'
 
 const defaultForm = {
   persistent: '',
@@ -1160,6 +1163,9 @@ export default {
         this.initTopicStats()
         this.dialogFormVisible = false
       })
+    },
+    hasAccess(namespace, permission) {
+      return hasPermissionToResource('NAMESPACES', namespace, permission)
     }
   }
 }

--- a/src/main/java/org/apache/pulsar/manager/controller/TenantsController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/TenantsController.java
@@ -124,7 +124,9 @@ public class TenantsController {
                 List<RoleInfoEntity> roleInfoEntities = rolesRepository.findAllRolesByMultiId(roleIdList);
                 List<Long> tenantsIdList = new ArrayList<>();
                 for (RoleInfoEntity roleInfoEntity : roleInfoEntities) {
-                    tenantsIdList.add(roleInfoEntity.getResourceId());
+                    if(roleInfoEntity.getResourceType().equals(ResourceType.TENANTS.name())) {
+                        tenantsIdList.add(roleInfoEntity.getResourceId());
+                    }
                 }
                 if (!tenantsIdList.isEmpty()) {
                     tenantEntities = tenantsRepository.findByMultiId(tenantsIdList);

--- a/src/main/java/org/apache/pulsar/manager/dao/TenantsRepositoryImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/dao/TenantsRepositoryImpl.java
@@ -79,4 +79,9 @@ public class TenantsRepositoryImpl implements TenantsRepository {
         tenantsMapper.delete(tenant);
     }
 
+    @Override
+    public List<TenantEntity> findByEnvironment(String environment) {
+        return tenantsMapper.findAll(environment);
+    }
+
 }

--- a/src/main/java/org/apache/pulsar/manager/entity/RoleInfoEntity.java
+++ b/src/main/java/org/apache/pulsar/manager/entity/RoleInfoEntity.java
@@ -51,4 +51,8 @@ public class RoleInfoEntity {
     @SerializedName("resource_verbs")
     private String resourceVerbs;
     private int flag;
+
+    @SerializedName("access")
+    private String access;
+
 }

--- a/src/main/java/org/apache/pulsar/manager/entity/TenantsRepository.java
+++ b/src/main/java/org/apache/pulsar/manager/entity/TenantsRepository.java
@@ -38,5 +38,7 @@ public interface TenantsRepository {
 
     void remove(String tenant);
 
+    List<TenantEntity> findByEnvironment(String environment);
+
 }
 

--- a/src/main/java/org/apache/pulsar/manager/mapper/RolesMapper.java
+++ b/src/main/java/org/apache/pulsar/manager/mapper/RolesMapper.java
@@ -29,45 +29,45 @@ import java.util.List;
 public interface RolesMapper {
 
     @Insert("INSERT INTO roles (role_name, description, resource_type, resource_name, resource_verbs," +
-            "resource_id, role_source, flag) " +
+            "resource_id, role_source, flag, access) " +
             "VALUES (#{roleName}, #{description}, #{resourceType}, #{resourceName}, #{resourceVerbs}," +
-            "#{resourceId}, #{roleSource}, #{flag})")
+            "#{resourceId}, #{roleSource}, #{flag}, #{access})")
     @Options(useGeneratedKeys=true, keyProperty="roleId", keyColumn="role_id")
     long save(RoleInfoEntity roleInfoEntity);
 
     @Select("SELECT role_id AS roleId, role_name AS roleName, description, resource_type AS resourceType," +
             "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-            "role_source AS roleSource, flag " +
+            "role_source AS roleSource, access AS access, flag " +
             "FROM roles " +
             "WHERE role_name = #{roleName} and role_source = #{roleSource}")
     RoleInfoEntity findByRoleName(@Param("roleName") String roleName, @Param("roleSource") String roleSource);
 
     @Select("SELECT role_id AS roleId, role_name AS roleName, description, resource_type AS resourceType," +
             "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-            "role_source AS roleSource, flag " +
+            "role_source AS roleSource, access AS access, flag " +
             "FROM roles " +
             "WHERE flag=#{flag} limit 1")
     RoleInfoEntity findByRoleFlag(@Param("flag") int flag);
 
     @Select("SELECT role_name AS roleName, role_id AS roleId, description, resource_type AS resourceType," +
             "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-            "role_source AS roleSource, flag FROM roles")
+            "role_source AS roleSource, access AS access, flag FROM roles")
     Page<RoleInfoEntity> findRoleList();
 
     @Select("SELECT role_name AS roleName, role_id AS roleId, description, resource_type AS resourceType," +
             "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-            "role_source AS roleSource, flag FROM roles")
+            "role_source AS roleSource, access AS access, flag FROM roles")
     List<RoleInfoEntity> findAllRoleList();
 
     @Select("SELECT role_name AS roleName, role_id AS roleId, description, resource_type AS resourceType," +
             "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-            "role_source AS roleSource, flag FROM roles WHERE role_source=#{roleSource}")
+            "role_source AS roleSource, access AS access, flag FROM roles WHERE role_source=#{roleSource}")
     List<RoleInfoEntity> findRoleListByRoleSource(String roleSource);
 
     @Select({"<script>",
             "SELECT role_name AS roleName, role_id AS roleId, description, resource_type AS resourceType," +
                     "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-                    "role_source AS roleSource, flag FROM roles",
+                    "role_source AS roleSource, access AS access, flag FROM roles",
             "WHERE role_id IN <foreach collection='roleIdList' item='roleId' open='(' separator=',' close=')'> #{roleId} </foreach>" +
                     "</script>"})
     Page<RoleInfoEntity> findByMultiId(@Param("roleIdList") List<Long> roleIdList);
@@ -75,7 +75,7 @@ public interface RolesMapper {
     @Select({"<script>",
             "SELECT role_name AS roleName, role_id AS roleId, description, resource_type AS resourceType," +
                     "resource_name AS resourceName, resource_verbs AS resourceVerbs, resource_id as resourceId," +
-                    "role_source AS roleSource, flag FROM roles",
+                    "role_source AS roleSource, access AS access , flag FROM roles",
             "WHERE role_id IN <foreach collection='roleIdList' item='roleId' open='(' separator=',' close=')'> #{roleId} </foreach>" +
                     "</script>"})
     List<RoleInfoEntity> findAllByMultiId(@Param("roleIdList") List<Long> roleIdList);

--- a/src/main/java/org/apache/pulsar/manager/mapper/TenantsMapper.java
+++ b/src/main/java/org/apache/pulsar/manager/mapper/TenantsMapper.java
@@ -77,4 +77,8 @@ public interface TenantsMapper {
     @Delete("DELETE FROM tenants WHERE tenant = #{tenant}")
     void delete(String tenant);
 
+    @Select("SELECT tenant, tenant_id as tenantId, admin_roles as adminRoles,allowed_clusters as allowedClusters," +
+            "environment_name as environmentName " +
+            "FROM tenants WHERE environment_name = #{environment}")
+    List<TenantEntity> findAll(String environment);
 }

--- a/src/main/resources/META-INF/sql/herddb-schema.sql
+++ b/src/main/resources/META-INF/sql/herddb-schema.sql
@@ -137,6 +137,7 @@ CREATE TABLE IF NOT EXISTS roles (
   resource_type varchar(48) NOT NULL,
   resource_name varchar(48) NOT NULL,
   resource_verbs varchar(256) NOT NULL,
+  access varchar(10) NOT NULL,
   flag INT NOT NULL
 );
 

--- a/src/main/resources/META-INF/sql/mysql-schema.sql
+++ b/src/main/resources/META-INF/sql/mysql-schema.sql
@@ -148,7 +148,8 @@ CREATE TABLE IF NOT EXISTS roles (
   resource_type varchar(48) NOT NULL,
   resource_name varchar(48) NOT NULL,
   resource_verbs varchar(256) NOT NULL,
-  flag INT NOT NULL
+  flag INT NOT NULL,
+  access varchar(10) NOT NULL
 )ENGINE=InnoDB CHARACTER SET utf8;
 
 CREATE TABLE IF NOT EXISTS tenants (

--- a/src/main/resources/META-INF/sql/postgresql-schema.sql
+++ b/src/main/resources/META-INF/sql/postgresql-schema.sql
@@ -148,6 +148,7 @@ CREATE TABLE IF NOT EXISTS roles (
   resource_type varchar(48) NOT NULL,
   resource_name varchar(48) NOT NULL,
   resource_verbs varchar(256) NOT NULL,
+  access varchar(10) NOT NULL,
   flag INT NOT NULL
 );
 

--- a/src/main/resources/META-INF/sql/sqlite-schema.sql
+++ b/src/main/resources/META-INF/sql/sqlite-schema.sql
@@ -144,7 +144,8 @@ CREATE TABLE IF NOT EXISTS roles (
   resource_type varchar(48) NOT NULL,
   resource_name varchar(48) NOT NULL,
   resource_verbs varchar(256) NOT NULL,
-  flag INT NOT NULL
+  flag INT NOT NULL,
+  access varchar(10) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS tenants (

--- a/src/test/java/org/apache/pulsar/manager/dao/RolesRepositoryImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/dao/RolesRepositoryImplTest.java
@@ -52,6 +52,8 @@ public class RolesRepositoryImplTest {
         roleInfoEntity.setResourceId(2);
         roleInfoEntity.setDescription("This is tenants permissions");
         roleInfoEntity.setFlag(0);
+        roleInfoEntity.setAccess("read");
+
     }
 
     private void validateRole(RoleInfoEntity role) {
@@ -63,6 +65,7 @@ public class RolesRepositoryImplTest {
         Assert.assertEquals(2, role.getResourceId());
         Assert.assertEquals("This is tenants permissions", role.getDescription());
         Assert.assertEquals(0, role.getFlag());
+        Assert.assertEquals("read",role.getAccess());
     }
 
     @Test

--- a/src/test/java/org/apache/pulsar/manager/dao/TenantsRepositoryImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/dao/TenantsRepositoryImplTest.java
@@ -129,4 +129,20 @@ public class TenantsRepositoryImplTest {
         Assert.assertEquals("test-cluster", getTenantEntity.getAllowedClusters());
         Assert.assertEquals("test-environment", getTenantEntity.getEnvironmentName());
     }
+
+    @Test
+    public void findByEnvironment() {
+        TenantEntity tenantEntity = new TenantEntity();
+        tenantEntity.setTenant("test");
+        tenantEntity.setAdminRoles("test-role");
+        tenantEntity.setAllowedClusters("test-cluster");
+        tenantEntity.setEnvironmentName("test-environment");
+        long tenantId = tenantsRepository.save(tenantEntity);
+        List<TenantEntity> result = tenantsRepository.findByEnvironment("test-environment");
+        TenantEntity getTenantEntity = result.get(0);
+        Assert.assertEquals("test", getTenantEntity.getTenant());
+        Assert.assertEquals("test-role", getTenantEntity.getAdminRoles());
+        Assert.assertEquals("test-cluster", getTenantEntity.getAllowedClusters());
+        Assert.assertEquals("test-environment", getTenantEntity.getEnvironmentName());
+    }
 }

--- a/src/test/java/org/apache/pulsar/manager/service/PulsarEventImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/PulsarEventImplTest.java
@@ -97,6 +97,7 @@ public class PulsarEventImplTest {
         superRoleInfoEntity.setResourceName("super-tenant-resource");
         superRoleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         superRoleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        superRoleInfoEntity.setAccess("write");
         superRoleId = rolesRepository.save(superRoleInfoEntity);
         RoleBindingEntity superRoleBindingEntity = new RoleBindingEntity();
         superRoleBindingEntity.setDescription("This is role binding description");
@@ -123,6 +124,7 @@ public class PulsarEventImplTest {
         adminRoleInfoEntity.setResourceName("admin-tenant-resource");
         adminRoleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         adminRoleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        adminRoleInfoEntity.setAccess("read");
         adminRoleId = rolesRepository.save(adminRoleInfoEntity);
         RoleBindingEntity adminRoleBindingEntity = new RoleBindingEntity();
         adminRoleBindingEntity.setDescription("This is role binding description");

--- a/src/test/java/org/apache/pulsar/manager/service/RoleBindingServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/RoleBindingServiceImplTest.java
@@ -95,6 +95,7 @@ public class RoleBindingServiceImplTest {
         roleInfoEntity.setResourceName("test-tenant-resource");
         roleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         roleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        roleInfoEntity.setAccess("read");
         long roleId = rolesRepository.save(roleInfoEntity);
         roleBindingEntity.setUserId(userId);
         roleBindingEntity.setRoleId(roleId);
@@ -140,6 +141,7 @@ public class RoleBindingServiceImplTest {
         roleInfoEntity.setResourceName("test-tenant-resource");
         roleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         roleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        roleInfoEntity.setAccess("read");
         long roleId = rolesRepository.save(roleInfoEntity);
         roleBindingEntity.setUserId(userId);
         roleBindingEntity.setRoleId(roleId);
@@ -165,6 +167,7 @@ public class RoleBindingServiceImplTest {
         testRoleInfoEntity.setResourceName("test-no-binding-tenant-resource");
         testRoleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         testRoleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        testRoleInfoEntity.setAccess("read");
         rolesRepository.save(testRoleInfoEntity);
 
         TenantEntity testNoBindingTenantEntity = new TenantEntity();
@@ -180,6 +183,7 @@ public class RoleBindingServiceImplTest {
         testNoBindingRoleInfoEntity.setResourceName("test-no-binding-tenant-resource");
         testNoBindingRoleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         testNoBindingRoleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        testNoBindingRoleInfoEntity.setAccess("read");
         rolesRepository.save(testNoBindingRoleInfoEntity);
 
         Map<String, Object> validateBindingRole = roleBindingService.validateCreateRoleBinding(
@@ -223,6 +227,7 @@ public class RoleBindingServiceImplTest {
         roleInfoEntity.setResourceName("test-tenant-resource");
         roleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         roleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        roleInfoEntity.setAccess("read");
         long roleId = rolesRepository.save(roleInfoEntity);
         roleBindingEntity.setUserId(userId);
         roleBindingEntity.setRoleId(roleId);

--- a/src/test/java/org/apache/pulsar/manager/service/RolesServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/RolesServiceImplTest.java
@@ -182,6 +182,7 @@ public class RolesServiceImplTest {
         roleInfoEntity.setResourceName("test-tenant-resource");
         roleInfoEntity.setResourceType(ResourceType.TENANTS.name());
         roleInfoEntity.setResourceVerbs(ResourceVerbs.ADMIN.name());
+        roleInfoEntity.setAccess("read");
         long roleId = rolesRepository.save(roleInfoEntity);
 
         RoleBindingEntity roleBindingEntity = new RoleBindingEntity();


### PR DESCRIPTION
### Motivation
Assign resource level read/write access to each role of a user. This way we can assign multiple resources to a user with read/write permission. 

* A user may exist with multiple resource access where he/she is allowed to only read a particular resource while for other resource it can make changes.*

### Modifications

* 1. Added access field at role level which can have read or write as value.
* 2. Added tenants field in resourceType list and will list available tenants in resource field while creating a role
* 3. Added access map (Map<String,Map<String,String>>) in /usersInfo response, each key is the resourceType and value holds another map with resourcename as value and value as read/write.
* 4. Added hasPermissionToResource method in module/users.js which is called for each actionable element when ui is rendered to decide to show/hide the resource based on access. 
* 5. Changes in .vue file to call the hasPermissionToResource method to decide if user has access to a particular element.

### Verifying this change

- [ ] Make sure that the change passes the `./gradlew build` checks.


