### PR TITLE
Updated to fix Log4J security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ jar {
     }
 }
 
+ext['log4j2.version'] = '2.17.1'
+
 dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: springBootVersion
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion


### PR DESCRIPTION
### Motivation

Details at https://logging.apache.org/log4j/2.x/security.html

Description of CVE-2021-45105:

> Apache Log4j2 versions 2.0-alpha1 through 2.16.0 did not protect from uncontrolled recursion from self-referential lookups. When the logging configuration uses a non-default Pattern Layout with a Context Lookup (for example, $${ctx:loginId}), attackers with control over Thread Context Map (MDC) input data can craft malicious input data that contains a recursive lookup, resulting in a StackOverflowError that will terminate the process. This is also known as a DOS (Denial of Service) attack.


*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

This PR applies the Log4j patch provided by the Spring Boot team. It forces the version of Log4J to 2.17.1.



