### PR TITLE
Add filterable to el-select enables filtering for tenant/namespace/topic

### DIFF
--- a/front-end/src/views/management/brokers/broker.vue
+++ b/front-end/src/views/management/brokers/broker.vue
@@ -23,7 +23,7 @@
           </el-select>
         </el-form-item>
         <el-form-item class="postInfo-container-item" label="Broker">
-          <el-select v-model="postForm.broker" placeholder="select broker" @change="changeBrokerInfo()">
+          <el-select v-model="postForm.broker" filterable placeholder="select broker" @change="changeBrokerInfo()">
             <el-option v-for="(item,index) in brokersListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>

--- a/front-end/src/views/management/namespaces/namespace.vue
+++ b/front-end/src/views/management/namespaces/namespace.vue
@@ -18,12 +18,12 @@
     <div class="createPost-container">
       <el-form :inline="true" :model="postForm" class="form-container">
         <el-form-item :label="$t('tenant.label')" class="postInfo-container-item">
-          <el-select v-model="postForm.tenant" :placeholder="$t('tenant.name')" @change="getNamespacesList(postForm.tenant)">
+          <el-select v-model="postForm.tenant" :placeholder="$t('tenant.name')" filterable @change="getNamespacesList(postForm.tenant)">
             <el-option v-for="(item,index) in tenantsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('namespace.label')" class="postInfo-container-item">
-          <el-select v-model="postForm.namespace" :placeholder="$t('namespace.name')" @change="getNamespaceInfo(postForm.tenant, postForm.namespace)">
+          <el-select v-model="postForm.namespace" :placeholder="$t('namespace.name')" filterable @change="getNamespaceInfo(postForm.tenant, postForm.namespace)">
             <el-option v-for="(item,index) in namespacesListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>

--- a/front-end/src/views/management/tenants/tenant.vue
+++ b/front-end/src/views/management/tenants/tenant.vue
@@ -18,7 +18,7 @@
     <div class="createPost-container">
       <el-form :inline="true" :model="postForm" class="form-container">
         <el-form-item class="postInfo-container-item" label="Tenant">
-          <el-select v-model="postForm.tenant" :placeholder="$t('tenant.selectTenantMessage')" @change="getNamespacesList(postForm.tenant)">
+          <el-select v-model="postForm.tenant" :placeholder="$t('tenant.selectTenantMessage')" filterable @change="getNamespacesList(postForm.tenant)">
             <el-option v-for="(item,index) in tenantsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>

--- a/front-end/src/views/management/topics/partitionedTopic.vue
+++ b/front-end/src/views/management/topics/partitionedTopic.vue
@@ -18,17 +18,17 @@
     <div class="createPost-container">
       <el-form :inline="true" :model="postForm" label-position="top" class="form-container">
         <el-form-item :label="$t('tenant.label')">
-          <el-select v-model="postForm.tenant" placeholder="select tenant" @change="getNamespacesList(postForm.tenant)">
+          <el-select v-model="postForm.tenant" placeholder="select tenant" filterable @change="getNamespacesList(postForm.tenant)">
             <el-option v-for="(item,index) in tenantsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('namespace.label')">
-          <el-select v-model="postForm.namespace" placeholder="select namespace" @change="getTopicsList()">
+          <el-select v-model="postForm.namespace" placeholder="select namespace" filterable @change="getTopicsList()">
             <el-option v-for="(item,index) in namespacesListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('topic.label')">
-          <el-select v-model="postForm.topic" placeholder="select topic" @change="getPartitionTopicInfo()">
+          <el-select v-model="postForm.topic" placeholder="select topic" filterable @change="getPartitionTopicInfo()">
             <el-option v-for="(item,index) in topicsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>

--- a/front-end/src/views/management/topics/topic.vue
+++ b/front-end/src/views/management/topics/topic.vue
@@ -18,22 +18,22 @@
     <div class="createPost-container">
       <el-form :inline="true" :model="postForm" class="form-container">
         <el-form-item :label="$t('tenant.label')">
-          <el-select v-model="postForm.tenant" placeholder="select tenant" @change="getNamespacesList(postForm.tenant)">
+          <el-select v-model="postForm.tenant" placeholder="select tenant" filterable @change="getNamespacesList(postForm.tenant)">
             <el-option v-for="(item,index) in tenantsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('namespace.label')">
-          <el-select v-model="postForm.namespace" placeholder="select namespace" @change="getTopicsList()">
+          <el-select v-model="postForm.namespace" placeholder="select namespace" filterable @change="getTopicsList()">
             <el-option v-for="(item,index) in namespacesListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('topic.label')">
-          <el-select v-model="postForm.topic" placeholder="select topic" @change="generatePartitions()">
+          <el-select v-model="postForm.topic" placeholder="select topic" filterable @change="generatePartitions()">
             <el-option v-for="(item,index) in topicsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>
         <el-form-item :label="$t('topic.partition')">
-          <el-select v-model="postForm.partition" :disabled="partitionDisabled" placeholder="select partition" @change="onPartitionChanged()">
+          <el-select v-model="postForm.partition" :disabled="partitionDisabled" filterable placeholder="select partition" @change="onPartitionChanged()">
             <el-option v-for="(item,index) in partitionsListOptions" :key="item+index" :label="item" :value="item"/>
           </el-select>
         </el-form-item>


### PR DESCRIPTION
Master Issue: #439 

### Motivation

Add filterable to el-select enables filtering for tenant/namespace/topic, which can be quite useful especially when there are many options.

### Modifications

Add filterable to el-select enables filtering.

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


