### PR TITLE
Align BouncyCastle transitive dependecies to 1.68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,4 +151,10 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: apiMockitoVersion
     testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: mockitoJunit4Version
+
+    constraints {
+        compile("org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}")
+        compile("org.bouncycastle:bcprov-ext-jdk15on:${bouncycastleVersion}")
+        compile("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ commonsValidatorVersion=1.6
 bkvmVersion=3.1.1
 tomcatVersion=8.5.31
 jerseyVersion=2.26
+bouncycastleVersion=1.68


### PR DESCRIPTION
Fixes #464 

### Motivation

In 0.3.0 there are two different versions of bc-prov which may cause runtime issues due to duplicate classes in the classloader

```
bcprov-ext-jdk15on-1.66.jar
bcprov-jdk15on-1.68.jar
```


### Modifications

* Set a fixed version for every bouncy-castle artifact to 1.68



