### PR TITLE
Fix URL for example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ bkvm address => http://localhost:7750/bkvm
     npm run dev
     ```
 
-After running these steps, the Pulsar Manager is running locally at http://127.0.0.1/#/environments.
+After running these steps, the Pulsar Manager is running locally at http://127.0.0.1:9527/#/environments.
 
 ## Access Pulsar Manager
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ After running these steps, the Pulsar Manager is running locally at http://127.0
 
 1. Access Pulsar manager UI at `http://${frontend-end-ip}/#/environments`.
 
-    If you started Pulsar Manager using docker or docker-compose, the Pulsar Manager is running at port 9527. You can access the Pulsar Manager UI at http://127.0.0.1/#/environments.
+    If you started Pulsar Manager using docker or docker-compose, the Pulsar Manager is running at port 9527. You can access the Pulsar Manager UI at http://127.0.0.1:9527/#/environments.
 
     If you are deploying Pulsar Manager 0.1.0 using the released container, you can log in the Pulsar Manager UI using the following credentials.
 


### PR DESCRIPTION

### Motivation

Attempting to use this section of the documentation, the intent of the initial documented link to localhost was clear but the implementation failed to include the port number, causing the link to be confusing at best. 

### Modifications

Added a port number to the URL in the example. 

### Verifying this change

No Checks should be required, as this is a documentation update, with valid Markdown. 
