### PR TITLE
Use correct path for initdb and pg_ctl

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -18,8 +18,8 @@
 # under the License.
 #
 
-initdb -D /data/postgresql
-pg_ctl -D /data/postgresql start
+/usr/lib/postgresql/13/bin/initdb -D /data/postgresql
+/usr/lib/postgresql/13/bin/pg_ctl -D /data/postgresql start
 createdb
 psql -f /pulsar-manager/init_db.sql
 


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-manager/issues/465

### Motivation
`initdb` and `pg_ctl` are no longer available in the v0.3.0 image. Most likely this is due to a switch from alpine or to a newer version of PostgreSQL (13).

This change fixes the not found issues for both of these.

### Verifying this change

- [x] Tested it locally by building the image and running it
- [x] Tested it on Kubernetes on a clean environment