### PR TITLE
Removing conflicting dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ repositories {
 
 configurations {
     testPlugins {}
+    all*.exclude group: 'org.bouncycastle', module: 'bc-fips'
+    all*.exclude group: 'io.netty', module: 'netty-tcnative-classes'
 }
 
 dependencies {


### PR DESCRIPTION
### Motivation

Backend service gives below error when using backend.broker.pulsarAdmin.authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls because of conflicting dependency bc-fips

```
java.lang.NoSuchFieldError: id_alg_AEADChaCha20Poly1305 at org.bouncycastle.jcajce.provider.symmetric.ChaCha$Mappings.configure(Unknown Source) ~[bcprov-jdk15on-1.68.jar:1.68.0] 
at org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(BouncyCastleProvider.java:245) ~[bcprov-jdk15on-1.68.jar:1.68.0] 
at org.bouncycastle.jce.provider.BouncyCastleProvider.setup(BouncyCastleProvider.java:167) ~[bcprov-jdk15on-1.68.jar:1.68.0] at org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(BouncyCastleProvider.java:58) ~[bcprov-jdk15on-1.68.jar:1.68.0]
at org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(BouncyCastleProvider.java:153) ~[bcprov-jdk15on-1.68.jar:1.68.0]
```
### Modifications
Removed the below conflicting dependencies:

1. group: **org.bouncycastle**, module: '**bc-fips**'
2. group: '**io.netty**', module: '**netty-tcnative-classes**'
