### PR TITLE
Removing transitive dependencies for log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ configurations {
     testPlugins {}
     all*.exclude group: 'org.bouncycastle', module: 'bc-fips'
     all*.exclude group: 'io.netty', module: 'netty-tcnative-classes'
+    all*.exclude group: 'log4j', module: 'log4j'
 }
 
 dependencies {


### PR DESCRIPTION
### Motivation
Removing transitive dependencies for `log4j:log4j:1.2.17`
version 2.17.1 is already added in the dependencies

### Modifications

Excluding transitive dependencies in build.gradle 

### Verifying this change

 The change passes the `./gradlew build` checks.


