### PR TITLE
Redirect notifications to the commits@ list instead of dev

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,3 +46,10 @@ github:
     merge:   false
     # disable rebase button:
     rebase:  false
+
+notifications:
+  commits:      commits@pulsar.apache.org
+  issues:       commits@pulsar.apache.org
+  pullrequests: commits@pulsar.apache.org
+  discussions:  dev@pulsar.apache.org
+  jira_options: link label


### PR DESCRIPTION

### Motivation

Redirect notifications to the commits@ list instead of dev

