### PR TITLE
For #492, Remove unused 'token'

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/controller/EnvironmentsController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/EnvironmentsController.java
@@ -103,7 +103,6 @@ public class EnvironmentsController {
     public ResponseEntity<Map<String, Object>> addEnvironment(
             @RequestBody EnvironmentEntity environmentEntity) {
         Map<String, Object> result = Maps.newHashMap();
-        String token = request.getHeader("token");
         Optional<EnvironmentEntity> environmentEntityBrokerOptional = environmentsRepository
                 .findByBroker(environmentEntity.getBroker());
         if (environmentEntityBrokerOptional.isPresent()) {
@@ -141,7 +140,6 @@ public class EnvironmentsController {
     @RequestMapping(value = "/environments/environment", method =  RequestMethod.POST)
     public ResponseEntity<Map<String, Object>> updateEnvironment(@RequestBody EnvironmentEntity environmentEntity) {
         Map<String, Object> result = Maps.newHashMap();
-        String token = request.getHeader("token");
         Optional<EnvironmentEntity> environmentEntityOptional = environmentsRepository
                 .findByName(environmentEntity.getName());
         if (!environmentEntityOptional.isPresent()) {


### PR DESCRIPTION
Fixes #492 

### Motivation
The "token" get from the request header, but we don't use it.

### Modifications

Remove the unused 'token'.

### Verifying this change

- [ ] Make sure that the change passes the `./gradlew build` checks.


