### PR TITLE
Use existing database if present

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -18,8 +18,11 @@
 # under the License.
 #
 
-/usr/lib/postgresql/13/bin/initdb -D /data/postgresql
-/usr/lib/postgresql/13/bin/pg_ctl -D /data/postgresql start
+# Start Postgres
+/usr/lib/postgresql/13/bin/pg_ctl -D /data/postgresql start || \
+  # If it fails, maybe the database is not intialized yet, so do it
+  (/usr/lib/postgresql/13/bin/initdb -D /data/postgresql && \
+  # Then try to start Postgres again
+  /usr/lib/postgresql/13/bin/pg_ctl -D /data/postgresql start)
 createdb
 psql -f /pulsar-manager/init_db.sql
-


### PR DESCRIPTION
### Motivation

Currently the database is always initialized at startup, even if it is already present, which disables persistence.

### Modifications

 In order to change that, I made it so that Postgres tries to load the database, and only initialize it if it fails.

### Verifying this change

- [ ] Make sure that the change passes the `./gradlew build` checks.


