### PR TITLE
Fix 307 redirect errors when connecting to multi-broker cluster

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/zuul/HttpsClientConfiguration.java
+++ b/src/main/java/org/apache/pulsar/manager/zuul/HttpsClientConfiguration.java
@@ -17,6 +17,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.ssl.SSLContexts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +47,12 @@ public class HttpsClientConfiguration {
 
     @Bean
     public CloseableHttpClient httpClient() throws Exception {
+        LaxRedirectStrategy customLaxRedirectStrategy = new LaxRedirectStrategy() {
+            @Override
+            protected boolean isRedirectable(final String method) {
+                return true;
+            }
+        };
         if (tlsEnabled) {
             Resource resource = new FileSystemResource(tlsKeystore);
             File trustStoreFile = resource.getFile();
@@ -68,9 +75,10 @@ public class HttpsClientConfiguration {
                     hostnameVerifier);
 
             return HttpClients.custom()
+                    .setRedirectStrategy(customLaxRedirectStrategy)
                     .setSSLSocketFactory(sslsf)
                     .build();
         }
-        return HttpClients.custom().build();
+        return HttpClients.custom().setRedirectStrategy(customLaxRedirectStrategy).build();
     }
 }


### PR DESCRIPTION
Fixes #274 

### Motivation

This change fixes the invalid redirect errors when the pulsar manager tries to connect to a multi broker cluster. 

### Modifications

Added a custom redirect strategy in the Http 
Client utilized by Zuul. This will make sure that POST/DELETE/PUT methods will also be redirected in addition to the default GET/HEAD methods.

### Verifying this change
<img width="1269" alt="Screen Shot 2022-12-29 at 1 51 27 AM" src="https://user-images.githubusercontent.com/10327630/209935280-d546daae-7790-409e-87e4-e8b642c65ce6.png">
<img width="865" alt="Screen Shot 2022-12-29 at 1 48 09 AM" src="https://user-images.githubusercontent.com/10327630/209935299-c41e4c5f-ce09-4a30-bdf5-3ff0b84e1583.png">

- [ x] Make sure that the change passes the `./gradlew build` checks.


