### PR TITLE
Fix create topic failure for non-partitioned topic

### DIFF
--- a/front-end/src/api/topics.js
+++ b/front-end/src/api/topics.js
@@ -81,14 +81,14 @@ export function fetchPartitionTopicStats(persistent, tenantNamespaceTopic, perPa
 export function putTopic(persistent, tenant, namespace, topic, data) {
   var url = `/${persistent}/${tenant}/${namespace}/${topic}`
   if (data > 0) {
-    url += '/partitions'
+    return putTopicByPartition(persistent, tenant, namespace, topic, data)
+  } else {
+    return request({
+      headers: {'Content-Type': 'application/json'},
+      url: BASE_URL_V2 + url,
+      method: 'put'
+    })
   }
-  return request({
-    headers: { 'Content-Type': 'application/json' },
-    url: BASE_URL_V2 + url,
-    method: 'put',
-    data
-  })
 }
 
 export function putTopicByPartition(persistent, tenant, namespace, topic, data) {


### PR DESCRIPTION
Fixes #495 

### Motivation

Creating non-partitioned topics causes a HTTP 400 error. The reason is that the Pulsar admin API for non-partitioned topics only supports a metadata map. But pulsar manager defaults to sending an integer(which would be as per partitioned topic creation API) causing the error

[Non-partitioned topic creation API](https://pulsar.apache.org/admin-rest-api/#operation/createNonPartitionedTopic)
[Partitioned topic creation API](https://pulsar.apache.org/admin-rest-api/#operation/createPartitionedTopic)

### Modifications

The modification is to detect if a partitioned or non-partitioned topic is being created and based on that deciding if the integer should be passed.

### Verifying this change
![Screen Shot 2022-12-29 at 2 24 14 AM](https://user-images.githubusercontent.com/10327630/209938658-c20b6260-6c80-4fcd-b528-c267bf093e5f.png)

- [ X ] Make sure that the change passes the `./gradlew build` checks.


