### PR TITLE
Fixes #528: 'this.postFormbroker' is undefind in broker.vue

### DIFF
--- a/front-end/src/views/management/brokers/broker.vue
+++ b/front-end/src/views/management/brokers/broker.vue
@@ -222,7 +222,7 @@ export default {
         for (var policy in res.data) {
           for (var i in res.data[policy].primary) {
             var regexPrimary = new RegExp(res.data[policy].primary[i])
-            if (regexPrimary.test(this.postFormbroker)) {
+            if (regexPrimary.test(this.postForm.broker)) {
               if (tempIsolationPolicy.indexOf(policy) < 0) {
                 tempIsolationPolicy.push(policy)
               }
@@ -230,7 +230,7 @@ export default {
           }
           for (var j in res.data[policy].secondary) {
             var regexSecondary = new RegExp(res.data[policy].secondary[j])
-            if (regexSecondary.test(this.postFormbroker)) {
+            if (regexSecondary.test(this.postForm.broker)) {
               if (tempIsolationPolicy.indexOf(policy) < 0) {
                 tempIsolationPolicy.push(policy)
               }


### PR DESCRIPTION
Fixes #528

Master Issue: #528

### Modifications

The `postFormbroker` property in the `broker.vue` is undefined

### Modifications

Replace 'this.postFormbroker' with 'this.postForm.broker'

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


