### PR TITLE
Fix invalid example. "create super-user api" command at `Access Pulsar Manager` of main `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,32 +174,21 @@ After running these steps, the Pulsar Manager is running locally at http://127.0
     * Account: `pulsar`
     * Password: `pulsar`
 
-    If you are deploying Pulsar Manager using the latest code, you can create a super-user using the following command.
-    Then you can use the super user credentials to log in the Pulsar Manager UI. 
-    Provide the following information in the command:
-
-   - `BACKEND_SERVICE`: The IP address or domain name of the backend service.
-   - `SU_PASSWORD`: The password should be more than or equal to 6 digits.
-   
-    ...then run 
+    If you are deploying Pulsar Manager using the latest code, you can create a super-user using the following command. Then you can use the super user credentials to log in the Pulsar Manager UI.
 
     ```shell
-    # (1) User needs to these values
-    BACKEND_SERVICE='your_backend_service'
-    SU_PASSWORD='your_password'
-
-    # (2) CSRF token retrieval
-    CSRF_TOKEN=$(curl http://$BACKEND_SERVICE:7750/pulsar-manager/csrf-token)
-
-    # (3) curl command with CSRF_TOKEN, BACKEND_SERVICE, and SU_PASSWORD variables
+    CSRF_TOKEN=$(curl http://backend-service:7750/pulsar-manager/csrf-token)
     curl \
-    -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
-    -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN;" \
-    -H 'Content-Type: application/json' \
-    -X PUT \
-    -d "{\"name\": \"admin\", \"password\": \"$SU_PASSWORD\", \"description\": \"test\", \"email\": \"username@test.org\"}" \
-    http://$BACKEND_SERVICE:7750/pulsar-manager/users/superuser
+        -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
+        -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN;" \
+        -H 'Content-Type: application/json' \
+        -X PUT \
+        -d '{"name": "admin", "password": "apachepulsar", "description": "test", "email": "username@test.org"}' \
+        http://backend-service:7750/pulsar-manager/users/superuser
     ```
+
+    * `backend-service`: The IP address or domain name of the backend service.
+    * `password`: The password should be more than or equal to 6 digits.
 
 2. Create an environment.
 


### PR DESCRIPTION
### Motivation

Fix example command at [Access Pulsar Manager](https://github.com/apache/pulsar-manager#access-pulsar-manager) as below.

![image](https://github.com/apache/pulsar-manager/assets/61615301/3ed0c4a8-da7f-4806-8952-96d9303f4724)

... which won't work because -d option comes "after" backend-service address.

### Modifications

- Modify example command to make the command valid.
- Apply `shell` format on the codeblock


### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.
