### PR TITLE
Remove JWT validation from production code

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/service/JwtService.java
+++ b/src/main/java/org/apache/pulsar/manager/service/JwtService.java
@@ -13,10 +13,6 @@
  */
 package org.apache.pulsar.manager.service;
 
-import io.jsonwebtoken.Claims;
-import org.springframework.stereotype.Service;
-
-import java.security.Key;
 import java.util.Optional;
 
 public interface JwtService {
@@ -26,8 +22,6 @@ public interface JwtService {
     Optional<String> getSubFromToken(String token);
 
     String createBrokerToken(String role, String expiryTime);
-
-    Claims validateBrokerToken(String token);
 
     void setToken(String key, String value);
 

--- a/src/test/java/org/apache/pulsar/manager/service/impl/BrokerTokensServiceImplTest.java
+++ b/src/test/java/org/apache/pulsar/manager/service/impl/BrokerTokensServiceImplTest.java
@@ -11,11 +11,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.pulsar.manager.service;
+package org.apache.pulsar.manager.service.impl;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jwts;
 import org.apache.pulsar.manager.PulsarManagerApplication;
 import org.apache.pulsar.manager.profiles.HerdDBTestProfile;
+import org.apache.pulsar.manager.service.impl.JwtServiceImpl;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +30,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.security.Key;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(SpringRunner.class)
@@ -47,13 +52,21 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class BrokerTokensServiceImplTest {
 
     @Autowired
-    private JwtService jwtService;
+    private JwtServiceImpl jwtService;
+
+    public Claims validateBrokerToken(String token) {
+        Key validationKey = jwtService.getSigningKey();
+        Jwt jwt = Jwts.parser()
+                .setSigningKey(validationKey)
+                .parse(token);
+        return (Claims) jwt.getBody();
+    }
 
     @Test
     public void createBrokerTokenTest() {
         String role = "test";
         String token = jwtService.createBrokerToken(role, null);
-        Claims jwtBody = jwtService.validateBrokerToken(token);
+        Claims jwtBody = validateBrokerToken(token);
         Assert.assertEquals(role, jwtBody.getSubject());
     }
 }


### PR DESCRIPTION
### Motivation

CodeQL was flagging the current use of JWT as being vulnerable as `validateBrokerToken` wasn't actually
performing validlidation of the signature.

Since the logic is unused, except for in test, the entire chunk of logic has been moved exclusively to tests.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

Move `JwtServiceImpl#validateBrokerToken` logic into `BrokerTokensServiceImplTest`

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


