### PR TITLE
fix init_db.sql to also take variables from environment

### DIFF
--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -16,8 +16,8 @@
 \set password `echo "$PASSWORD"`
 
 ALTER USER :username WITH PASSWORD :'password';
-CREATE DATABASE pulsar_manager OWNER pulsar;
-GRANT ALL PRIVILEGES ON DATABASE pulsar_manager to pulsar;
+CREATE DATABASE pulsar_manager OWNER :username;
+GRANT ALL PRIVILEGES ON DATABASE pulsar_manager to :username;
 
 \c pulsar_manager;
 

--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -12,8 +12,8 @@
 -- limitations under the License.
 --
 
-\set username `echo "$USERNAME"`
-\set password `echo "$PASSWORD"`
+\set username `echo "${USERNAME:-pulsar}"`
+\set password `echo "${PASSWORD:-pulsar}"`
 
 ALTER USER :username WITH PASSWORD :'password';
 CREATE DATABASE pulsar_manager OWNER :username;

--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -12,7 +12,10 @@
 -- limitations under the License.
 --
 
-ALTER USER pulsar WITH PASSWORD 'pulsar';
+\set username `echo "$USERNAME"`
+\set password `echo "$PASSWORD"`
+
+ALTER USER :username WITH PASSWORD :'password';
 CREATE DATABASE pulsar_manager OWNER pulsar;
 GRANT ALL PRIVILEGES ON DATABASE pulsar_manager to pulsar;
 


### PR DESCRIPTION
### Motivation
The init script inside the docker container did not depend on the environment variables that were set in the backend (USERNAME / PASSWORD). This can lead to problems when trying to connect to the database and expecting the same credentials as set in the environment.

No errors where visible because postgre "trusts" connections from localhost by default, hence the backend did not have to authenticate / was allowed to authenticate incorrectly. 

### Modifications
The first SQL command to alter the role is made dependent on the environment variables.

### Verifying this change
- [ ] Make sure that the change passes the `./gradlew build` checks. (they are not part of these checks I assume)

