### PR TITLE
fix: spring boot 2.5 requires tomcat 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-jdk14'
         exclude group: 'org.herddb', module: '*'
     }
+    implementation (group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: tomcatVersion)
     implementation (group: 'org.apache.tomcat.embed', name: 'tomcat-embed-jasper', version: tomcatVersion)
     implementation group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
     implementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ postgresqlVersion=42.2.5
 herddbVersion=0.28.0
 commonsValidatorVersion=1.6
 bkvmVersion=3.1.1
-tomcatVersion=8.5.31
+tomcatVersion=9.0.52
 jerseyVersion=2.26
 bouncycastleVersion=1.68


### PR DESCRIPTION


### Motivation

Running the master branch currently fails as there is a depdendency mismatch, spring boot 2.5 requires tomcat 9.

### Modifications

- Update the gradle dependencies to use tomcat 9
- TldParser is required, adding tomcat-embed-core as dependency

### Verifying this change

- [X] Make sure that the change passes the `./gradlew build` checks.


