### PR TITLE
fix: add token column to init sql

### DIFF
--- a/docker/init_db.sql
+++ b/docker/init_db.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS environments (
   name varchar(256) NOT NULL,
   broker varchar(1024) NOT NULL,
   bookie varchar(1024) NOT NULL,
+  token varchar(1024),
   CONSTRAINT PK_name PRIMARY KEY (name),
   UNIQUE (broker)
 );


### PR DESCRIPTION
### Motivation

commit ee83cd2 adds environment specific token, which is missing in the init sql.

### Modifications

* add token column to the init sql.

### Verifying this change

- [X] Make sure that the change passes the `./gradlew build` checks.


