### PR TITLE
Fix: ErrorController.getErrorPath()

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/PulsarManagerApplication.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarManagerApplication.java
@@ -16,9 +16,10 @@ package org.apache.pulsar.manager;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {ErrorMvcAutoConfiguration.class})
 @EnableZuulProxy
 @MapperScan("org.apache.pulsar.manager.mapper")
 public class PulsarManagerApplication {


### PR DESCRIPTION

Fixes #560

### Motivation

Workaround to fix error with spring boot 2.5

### Modifications

No ErrorController is used, thus exclude it to prevent zuul accessing it.
the zuul implementation should be replaced sepparately.

### Verifying this change

- [X] Make sure that the change passes the `./gradlew build` checks.


