### PR TITLE
fix: check for existing superuser

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/controller/UsersController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/UsersController.java
@@ -218,6 +218,11 @@ public class UsersController {
             result.put("error", "Please provider password");
             return ResponseEntity.ok(result);
         }
+        Optional<UserInfoEntity> optionalUserEntity =  usersRepository.findByUserName(userInfoEntity.getName());
+        if (optionalUserEntity.isPresent()) {
+            result.put("error", "Superuser already exists");
+            return ResponseEntity.ok(result);
+        }
 
         userInfoEntity.setPassword(DigestUtils.sha256Hex(userInfoEntity.getPassword()));
         usersRepository.save(userInfoEntity);


### PR DESCRIPTION
Fixes #563 and #537

### Motivation

When creating superuser, currently there's no guard to protect against already created superuser. 
If you seed superuser more then one times, it breaks login for that particular user as the request throws `InternalServerError` on login

### Modifications

In the same style of other guards within `UsersController` I've added query to repository to get entity by name for the incoming user payload. If the entity exists we return validation error.

### Verifying this change
- [x] Make sure that the change passes the `./gradlew build` checks.


