### PR TITLE
feat: support seeding default superuser via application.properties

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,15 +8,13 @@ Pulsar manager backend is a supplement and improvement to Pulsar broker.
 
 ### Supported configurations of backend
 
-| Name | Default |Description
-| ------- | ------- | ------- |
-| `server.port` | 7750 | Port of backend service |
-| `pulsar-manager.account` | pulsar | Login account |
-| `pulsar-manager.password` | pulsar | Login password |
-| `redirect.host` | localhost | IP address of front-end service |
-| `redirect.port` | 9527 | Port of front-end service |
-| `insert.stats.interval` | 30000ms | Time interval for collecting statistical information |
-| `clear.stats.interval` | 300000ms | Time interval for cleaning statistics |
+| Name                    | Default   | Description                                          |
+| ----------------------- | --------- | ---------------------------------------------------- |
+| `server.port`           | 7750      | Port of backend service                              |
+| `redirect.host`         | localhost | IP address of front-end service                      |
+| `redirect.port`         | 9527      | Port of front-end service                            |
+| `insert.stats.interval` | 30000ms   | Time interval for collecting statistical information |
+| `clear.stats.interval`  | 300000ms  | Time interval for cleaning statistics                |
 
 ### How to set parameters when starting back-end services
 

--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.manager.entity.EnvironmentEntity;
 import org.apache.pulsar.manager.entity.EnvironmentsRepository;
+import org.apache.pulsar.manager.entity.UsersRepository;
 import org.apache.pulsar.manager.service.PulsarAdminService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -61,7 +61,7 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     private String defaultEnvironmentBookieUrl;
 
     @Value("${default.superuser.enable}")
-    private Boolean defaultSuperuserEnable;
+    private Boolean defaultSuperuserEnable = false;
 
     @Value("${default.superuser.name}")
     private String defaultSuperuserName;

--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -94,7 +94,7 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     }
 
     private void seedDefaultSuperuser() {
-        if(defaultSuperuserEnable) {
+        if(defaultSuperuserEnable == false) {
             log.debug("Superuser seed disabled");
             return;
         }

--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -13,20 +13,28 @@
  */
 package org.apache.pulsar.manager;
 
-import com.github.pagehelper.Page;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.manager.entity.EnvironmentEntity;
 import org.apache.pulsar.manager.entity.EnvironmentsRepository;
+import org.apache.pulsar.manager.entity.UserInfoEntity;
 import org.apache.pulsar.manager.entity.UsersRepository;
 import org.apache.pulsar.manager.service.PulsarAdminService;
+import org.apache.pulsar.manager.service.UsersService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
+import com.github.pagehelper.Page;
+
+import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * PulsarApplicationListener do something after the spring framework initialization is complete.
@@ -41,6 +49,8 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
 
     private final UsersRepository usersRepository;
 
+    private final UsersService usersService;
+
     @Value("${default.environment.name}")
     private String defaultEnvironmentName;
 
@@ -51,7 +61,7 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     private String defaultEnvironmentBookieUrl;
 
     @Value("${default.superuser.enable}")
-    private String defaultSuperuserEnable;
+    private Boolean defaultSuperuserEnable;
 
     @Value("${default.superuser.name}")
     private String defaultSuperuserName;
@@ -66,11 +76,13 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     public PulsarApplicationListener(
         EnvironmentsRepository environmentsRepository, 
         PulsarAdminService pulsarAdminService,
-        UsersRepository usersRepository
+        UsersRepository usersRepository,
+        UsersService usersService
     ) {
         this.environmentsRepository = environmentsRepository;
         this.pulsarAdminService = pulsarAdminService;
         this.usersRepository = usersRepository;
+        this.usersService = usersService;
     }
 
     @Override

--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -49,27 +49,17 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     @Value("${default.environment.bookie_url}")
     private String defaultEnvironmentBookieUrl;
 
+    @Value("${default.superuser.enable}")
+    private String defaultSuperuserEnable;
+
     @Value("${default.superuser.name}")
     private String defaultSuperuserName;
-
-    @Value("${default.superuser.password}")
-    private String defaultSuperuserPassword;
-
-    @Value("${default.superuser.description}")
-    private String defaultSuperuserDescription;
-
-    @Value("${default.superuser.location}")
-    private String defaultSuperuserLocation;
-
-    @Value("${default.superuser.company}")
-    private String defaultSuperuserCompany;
-
-    @Value("${default.superuser.phoneNumber}")
-    private String defaultSuperuserPhoneNumber;
 
     @Value("${default.superuser.email}")
     private String defaultSuperuserEmail;
 
+    @Value("${default.superuser.password}")
+    private String defaultSuperuserPassword;
 
     @Autowired
     public PulsarApplicationListener(
@@ -91,14 +81,15 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     }
 
     private void seedDefaultSuperuser() {
+        if(defaultSuperuserEnable) {
+            log.debug("Superuser seed disabled");
+            return;
+        }
+        
         UserInfoEntity userInfoEntity = new UserInfoEntity();
         userInfoEntity.setName(defaultSuperuserName);
-        userInfoEntity.setPassword(defaultSuperuserPassword);
-        userInfoEntity.setDescription(defaultSuperuserDescription);
-        userInfoEntity.setLocation(defaultSuperuserLocation);
-        userInfoEntity.setCompany(defaultSuperuserCompany);
-        userInfoEntity.setPhoneNumber(defaultSuperuserPhoneNumber);
         userInfoEntity.setEmail(defaultSuperuserEmail);
+        userInfoEntity.setPassword(defaultSuperuserPassword);
 
         Map<String, String> userValidateResult = usersService.validateUserInfo(userInfoEntity);
         if (userValidateResult.get("error") != null) {
@@ -112,7 +103,7 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
         
         Optional<UserInfoEntity> optionalUserEntity =  usersRepository.findByUserName(userInfoEntity.getName());
         if (optionalUserEntity.isPresent()) {
-            log.error("Superuser already exists.");
+            log.warn("Superuser already exists.");
             return;
         }
 

--- a/src/main/java/org/apache/pulsar/manager/controller/LoginController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/LoginController.java
@@ -65,12 +65,6 @@ public class LoginController {
     @Autowired
     private CasdoorAuthService casdoorAuthService;
 
-    @Value("${pulsar-manager.account}")
-    private String account;
-
-    @Value("${pulsar-manager.password}")
-    private String password;
-
     @ApiOperation(value = "Login pulsar manager")
     @ApiResponses({@ApiResponse(code = 200, message = "ok"), @ApiResponse(code = 500, message = "Internal server error")})
     @RequestMapping(value = "/login", method = RequestMethod.POST)

--- a/src/main/java/org/apache/pulsar/manager/controller/UsersController.java
+++ b/src/main/java/org/apache/pulsar/manager/controller/UsersController.java
@@ -54,12 +54,6 @@ import java.util.Set;
 @Api(description = "Functions under this class are available to super user.")
 public class UsersController {
 
-    @Value("${user.management.enable}")
-    private boolean userManagementEnable;
-
-    @Value("${pulsar-manager.account}")
-    private String account;
-
     private final UsersRepository usersRepository;
 
     private final UsersService usersService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -84,11 +84,6 @@ backend.broker.pulsarAdmin.tlsEnableHostnameVerification=false
 
 jwt.secret=dab1c8ba-b01b-11e9-b384-186590e06885
 jwt.sessionTime=2592000
-# If user.management.enable is true, the following account and password will no longer be valid.
-pulsar-manager.account=pulsar
-pulsar-manager.password=pulsar
-# If true, the database is used for user management
-user.management.enable=true
 
 # Optional -> SECRET, PRIVATE, default -> PRIVATE, empty -> disable auth
 # SECRET mode -> bin/pulsar tokens create --secret-key file:///path/to/my-secret.key --subject test-user

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -134,12 +134,9 @@ default.environment.service_url=
 default.environment.bookie_url=
 
 # default superuser configuration
+default.superuser.enable=
 default.superuser.name=
 default.superuser.password=
-default.superuser.description=
-default.superuser.location=
-default.superuser.company=
-default.superuser.phoneNumber=
 default.superuser.email=
 
 # enable tls encryption

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -132,6 +132,16 @@ spring.thymeleaf.mode=HTML5
 default.environment.name=
 default.environment.service_url=
 default.environment.bookie_url=
+
+# default superuser configuration
+default.superuser.name=
+default.superuser.password=
+default.superuser.description=
+default.superuser.location=
+default.superuser.company=
+default.superuser.phoneNumber=
+default.superuser.email=
+
 # enable tls encryption
 # keytool -import -alias test-keystore -keystore ca-certs -file certs/ca.cert.pem
 tls.enabled=false


### PR DESCRIPTION
Fixes #563 

### Motivation

I'm working on integrating apache pulsar into [.NET Aspire](https://github.com/dotnet/aspire)
Next to pulsar I wish to deliver a management UI, pulsar manager. Like Kafka and Rabbit do.

Here's [my implementation](https://github.com/maranmaran/aspire/tree/feature/hosting-apache-pulsar/src/Aspire.Hosting.Apache.Pulsar)

Right now, in order for me to seed default superuser, I must do this gymnastics of waiting for container and backend to be ready then acquire token, then issue put request.

This is clumsy a little and there should be a way to provide some default superuser via configuration. Like rabbit does, SQL, bunch of other tools.

In particular I'm afraid that Aspire team [won't accept a solution like this one](https://github.com/maranmaran/aspire/blob/feature/hosting-apache-pulsar/src/Aspire.Hosting.Apache.Pulsar/PulsarManagerSeedDefaultSuperUser.cs)

Where I subscribe lifecycle hooks of container and then retry loop till I seed the user.
It works, but it feels too "hacky"

### Modifications

In `PulsarApplicationListener` implemented `seedDefaultSuperuser`
Removed obsolete `pulsar-manager.account`

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


