### PR TITLE
fix: remove circular dep in admin svc, adjusts default superuser env flag name and default  

### DIFF
--- a/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
+++ b/src/main/java/org/apache/pulsar/manager/PulsarApplicationListener.java
@@ -60,8 +60,8 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     @Value("${default.environment.bookie_url}")
     private String defaultEnvironmentBookieUrl;
 
-    @Value("${default.superuser.enable}")
-    private Boolean defaultSuperuserEnable = false;
+    @Value("${default.superuser.enabled}")
+    private Boolean defaultSuperuserEnabled;
 
     @Value("${default.superuser.name}")
     private String defaultSuperuserName;
@@ -94,8 +94,8 @@ public class PulsarApplicationListener implements ApplicationListener<ContextRef
     }
 
     private void seedDefaultSuperuser() {
-        if(defaultSuperuserEnable == false) {
-            log.debug("Superuser seed disabled");
+        if(defaultSuperuserEnabled == false) {
+            log.info("Superuser seed via application.properties is disabled");
             return;
         }
         

--- a/src/main/java/org/apache/pulsar/manager/service/impl/PulsarAdminServiceImpl.java
+++ b/src/main/java/org/apache/pulsar/manager/service/impl/PulsarAdminServiceImpl.java
@@ -71,9 +71,6 @@ public class PulsarAdminServiceImpl implements PulsarAdminService {
     @Autowired
     private EnvironmentsRepository environmentsRepository;
 
-    @Autowired
-    private EnvironmentCacheService environmentCacheService;
-
     @PreDestroy
     public void destroy() {
         pulsarAdmins.values().forEach(value -> value.close());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -134,7 +134,7 @@ default.environment.service_url=
 default.environment.bookie_url=
 
 # default superuser configuration
-default.superuser.enable=
+default.superuser.enabled=false
 default.superuser.name=
 default.superuser.password=
 default.superuser.email=


### PR DESCRIPTION
### Motivation
Fixes #https://github.com/apache/pulsar-manager/issues/567
Tiny adjustment on parent PR #565 to match convention on flag name and it's bool default

### Modifications

- [x] Remove unused service ref in `PulsarAdminServiceImpl` causing circular ref.
- [x] Rename `default.superuser.enable` -> `default.superuser.enabled` to match the convention
- [x] Default `default.superuser.enabled` flag to false in `application.properties`, remove from code  
- [x] Adjust log entry when default superuser flag is disabled

### Verifying this change

- [x] Make sure that the change passes the `./gradlew build` checks.


